### PR TITLE
Add BLE command helpers and password configuration

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -84,6 +84,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: LD2410ConfigEntry) -> bo
         retry_count=entry.options[CONF_RETRY_COUNT],
     )
 
+    try:
+        await device.initialise()
+    except Exception as err:  # pragma: no cover - defensive
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="value_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
     coordinator = entry.runtime_data = LD2410DataUpdateCoordinator(
         hass,
         _LOGGER,

--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import (
     CONF_ADDRESS,
+    CONF_PASSWORD,
     CONF_SENSOR_TYPE,
 )
 from homeassistant.core import callback
@@ -32,6 +33,7 @@ from .const import (
     NON_CONNECTABLE_SUPPORTED_MODEL_TYPES,
     SUPPORTED_MODEL_TYPES,
 )
+from .api.ld2410.const import CMD_BT_PASS_DEFAULT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,7 +127,13 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(
             step_id="confirm",
-            data_schema=vol.Schema({}),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_PASSWORD, default=CMD_BT_PASS_DEFAULT.decode()
+                    ): str,
+                }
+            ),
             description_placeholders={
                 "name": name_from_discovery(self._discovered_adv)
             },
@@ -175,7 +183,7 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             device_adv = self._discovered_advs[user_input[CONF_ADDRESS]]
             await self._async_set_device(device_adv)
-            return await self._async_create_entry_from_discovery(user_input)
+            return await self.async_step_confirm()
 
         self._async_discover_devices()
         if len(self._discovered_advs) == 1:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,10 +12,10 @@ try:
 except ImportError:
     from homeassistant.config_entries import ConfigEntry
     from typing import Any
-    
+
     class MockConfigEntry(ConfigEntry):
         """Mock config entry for testing."""
-        
+
         def __init__(
             self,
             *,
@@ -41,20 +41,23 @@ except ImportError:
                 "entry_id": entry_id or "mock_entry_id",
                 "unique_id": unique_id,
                 "discovery_keys": {},  # Required for newer HA versions
-                "subentries_data": {},  # Required for newer HA versions
             }
             super().__init__(**kwargs)
-        
+
         def add_to_hass(self, hass: HomeAssistant) -> None:
             """Add this entry to Home Assistant."""
             hass.config_entries._entries[self.entry_id] = self
 
+
 try:
-    from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
+    from tests.components.bluetooth import (
+        generate_advertisement_data,
+        generate_ble_device,
+    )
 except ImportError:
     from bleak.backends.device import BLEDevice
     from bleak import AdvertisementData
-    
+
     def generate_advertisement_data(
         local_name: str | None = None,
         manufacturer_data: dict[int, bytes] | None = None,
@@ -73,7 +76,7 @@ except ImportError:
             rssi=rssi,
             platform_data=(),
         )
-    
+
     def generate_ble_device(
         address: str,
         name: str | None = None,
@@ -84,6 +87,7 @@ except ImportError:
             name=name,
             details={},
         )
+
 
 DOMAIN = "ld2410"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,10 @@ try:
 except ImportError:
     from homeassistant.config_entries import ConfigEntry
     from typing import Any
-    
+
     class MockConfigEntry(ConfigEntry):
         """Mock config entry for testing."""
-        
+
         def __init__(
             self,
             *,
@@ -45,7 +45,8 @@ except ImportError:
 
 from custom_components.ld2410.const import DOMAIN
 
-@pytest.fixture(autouse=True)
+
+@pytest.fixture
 def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 

--- a/tests/test_ble_commands.py
+++ b/tests/test_ble_commands.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+import pytest
+from bleak.backends.device import BLEDevice
+from homeassistant.core import HomeAssistant
+
+from custom_components.ld2410.api.ld2410.devices.device import LD2410Device
+from custom_components.ld2410.api.ld2410.const import (
+    CHARACTERISTIC_NOTIFY,
+    CHARACTERISTIC_WRITE,
+    CMD_BT_PASS_POST,
+    CMD_BT_PASS_PRE,
+    CMD_DISABLE_CONFIG,
+    CMD_ENABLE_CONFIG,
+    CMD_ENABLE_ENGINEERING_MODE,
+)
+
+
+class MockCharacteristic:
+    def __init__(self, uuid: str) -> None:
+        self.uuid = uuid
+
+
+class MockServices:
+    def get_characteristic(self, uuid):  # type: ignore[override]
+        return MockCharacteristic(str(uuid))
+
+
+class MockClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.services = MockServices()
+        self.write_calls: list[tuple[str, bytes]] = []
+        self.notify_calls: list[str] = []
+
+    async def write_gatt_char(self, char, data, response):
+        self.write_calls.append((char.uuid, data))
+
+    async def start_notify(self, char, callback):
+        self.notify_calls.append(char.uuid)
+
+    async def disconnect(self):
+        return
+
+
+@pytest.mark.asyncio
+async def test_initialise_sends_commands_using_correct_characteristics(
+    hass: HomeAssistant,
+) -> None:
+    ble_device = BLEDevice("AA:BB:CC:DD:EE:FF", "test", {})
+    client = MockClient()
+
+    async def mock_ensure_connected(self):
+        self._client = client
+        self._read_char = MockCharacteristic(CHARACTERISTIC_NOTIFY)
+        self._write_char = MockCharacteristic(CHARACTERISTIC_WRITE)
+        await client.start_notify(self._read_char, self._notification_handler)
+
+    with patch(
+        "custom_components.ld2410.api.ld2410.devices.device.LD2410BaseDevice._ensure_connected",
+        mock_ensure_connected,
+    ):
+        device = LD2410Device(device=ble_device, password="HiLink")
+        await device.initialise()
+        await device._execute_disconnect()
+
+    expected_first = CMD_BT_PASS_PRE + b"HiLink" + CMD_BT_PASS_POST
+    assert client.notify_calls[0] == CHARACTERISTIC_NOTIFY
+    assert client.write_calls == [
+        (CHARACTERISTIC_WRITE, expected_first),
+        (CHARACTERISTIC_WRITE, CMD_ENABLE_CONFIG),
+        (CHARACTERISTIC_WRITE, CMD_ENABLE_ENGINEERING_MODE),
+        (CHARACTERISTIC_WRITE, CMD_DISABLE_CONFIG),
+    ]


### PR DESCRIPTION
## Summary
- subscribe to LD2410 notify characteristic on connect
- add raw BLE command helpers and initialization sequence
- allow password entry during setup with default HiLink
- test BLE command characteristic usage

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410`

## Test Coverage
- 37%

------
https://chatgpt.com/codex/tasks/task_e_689fc22c123083308da88b158b77b02f