### PR TITLE
Prefill LD2410 config flow password

### DIFF
--- a/custom_components/ld2410/api/ld2410/adv_parser.py
+++ b/custom_components/ld2410/api/ld2410/adv_parser.py
@@ -11,16 +11,14 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 from .adv_parsers.contact import process_wocontact
-from .adv_parsers.motion import process_wopresence
 from .adv_parsers.ld2410 import process_ld2410
+from .adv_parsers.motion import process_wopresence
 from .const import LD2410Model
 from .models import LD2410Advertisement
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_DATA_ORDER = (
-    "0000af30-0000-1000-8000-00805f9b34fb",
-)
+SERVICE_DATA_ORDER = ("0000af30-0000-1000-8000-00805f9b34fb",)
 MFR_DATA_ORDER = (256, 1494)
 
 
@@ -123,10 +121,8 @@ def _parse_data(
     """Parse advertisement data."""
     type_data = SUPPORTED_TYPES.get("t")
 
-    data = {
+    return {
         "modelFriendlyName": type_data["modelFriendlyName"],
         "modelName": type_data["modelName"],
         "data": type_data["func"](_service_data, _mfr_data),
     }
-
-    return data

--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -18,11 +18,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.const import (
-    CONF_ADDRESS,
-    CONF_SENSOR_TYPE,
-    CONF_PASSWORD
-)
+from homeassistant.const import CONF_ADDRESS, CONF_SENSOR_TYPE, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from .const import (
@@ -100,7 +96,7 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
         return await self.async_step_confirm()
 
     async def async_step_password(
-            self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the password step."""
         assert self._discovered_adv is not None
@@ -112,7 +108,9 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="password",
-            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            data_schema=vol.Schema(
+                {vol.Required(CONF_PASSWORD, default="HiLink"): str}
+            ),
             description_placeholders={
                 "name": name_from_discovery(self._discovered_adv)
             },

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-homeassistant>=2025.3.0
+homeassistant==2025.1.4
 pytest>=8
 pytest-asyncio>=0.23
 pytest-cov

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-homeassistant>=2024.12.0
+homeassistant>=2025.3.0
 pytest>=8
 pytest-asyncio>=0.23
 pytest-cov

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,12 @@
+"""Local test utilities overriding upstream.
+
+Provides MockConfigEntry and BLE helpers for tests.
+"""
+
+from .mocks import MockConfigEntry, generate_advertisement_data, generate_ble_device
+
+__all__ = [
+    "MockConfigEntry",
+    "generate_advertisement_data",
+    "generate_ble_device",
+]

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -24,6 +24,7 @@ class MockConfigEntry(ConfigEntry):
         unique_id: str | None = None,
         version: int = 1,
         minor_version: int = 1,
+        subentries_data: tuple[dict[str, Any], ...] | None = None,
     ) -> None:
         """Initialize a mock config entry."""
         kwargs = {
@@ -37,6 +38,7 @@ class MockConfigEntry(ConfigEntry):
             "entry_id": entry_id or "mock_entry_id",
             "unique_id": unique_id,
             "discovery_keys": {},
+            "subentries_data": subentries_data or (),
         }
         super().__init__(**kwargs)
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,5 +1,6 @@
 from typing import Any
 from collections.abc import Callable, Coroutine
+import inspect
 
 from aiohttp.test_utils import TestClient
 from bleak import AdvertisementData
@@ -38,8 +39,9 @@ class MockConfigEntry(ConfigEntry):
             "entry_id": entry_id or "mock_entry_id",
             "unique_id": unique_id,
             "discovery_keys": {},
-            "subentries_data": subentries_data or (),
         }
+        if "subentries_data" in inspect.signature(ConfigEntry.__init__).parameters:
+            kwargs["subentries_data"] = subentries_data or ()
         super().__init__(**kwargs)
 
     def add_to_hass(self, hass: HomeAssistant) -> None:

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,23 +1,29 @@
+from typing import Any
+from collections.abc import Callable, Coroutine
+
+from aiohttp.test_utils import TestClient
+from bleak import AdvertisementData
+from bleak.backends.device import BLEDevice
+from habluetooth import BluetoothServiceInfo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from typing import Any
+
 
 class MockConfigEntry(ConfigEntry):
     """Mock config entry for testing."""
 
     def __init__(
-            self,
-            *,
-            domain: str,
-            data: dict[str, Any] | None = None,
-            options: dict[str, Any] | None = None,
-            entry_id: str | None = None,
-            source: str = "user",
-            title: str = "Mock Title",
-            unique_id: str | None = None,
-            version: int = 1,
-            minor_version: int = 1,
-            subemtries_data: dict[str, Any] | None = None,
+        self,
+        *,
+        domain: str,
+        data: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+        entry_id: str | None = None,
+        source: str = "user",
+        title: str = "Mock Title",
+        unique_id: str | None = None,
+        version: int = 1,
+        minor_version: int = 1,
     ) -> None:
         """Initialize a mock config entry."""
         kwargs = {
@@ -31,8 +37,6 @@ class MockConfigEntry(ConfigEntry):
             "entry_id": entry_id or "mock_entry_id",
             "unique_id": unique_id,
             "discovery_keys": {},
-            'subentries_data': subemtries_data or {},
-            # Required for newer HA versions
         }
         super().__init__(**kwargs)
 
@@ -41,19 +45,13 @@ class MockConfigEntry(ConfigEntry):
         hass.config_entries._entries[self.entry_id] = self
 
 
-from bleak.backends.device import BLEDevice
-from bleak import AdvertisementData
-from habluetooth import BluetoothServiceInfo
-from collections.abc import Callable, Coroutine
-from aiohttp.test_utils import TestClient
-
 def generate_advertisement_data(
-        local_name: str | None = None,
-        manufacturer_data: dict[int, bytes] | None = None,
-        service_data: dict[str, bytes] | None = None,
-        service_uuids: list[str] | None = None,
-        tx_power: int | None = None,
-        rssi: int = -60,
+    local_name: str | None = None,
+    manufacturer_data: dict[int, bytes] | None = None,
+    service_data: dict[str, bytes] | None = None,
+    service_uuids: list[str] | None = None,
+    tx_power: int | None = None,
+    rssi: int = -60,
 ):
     """Generate advertisement data for testing."""
     return AdvertisementData(
@@ -66,9 +64,10 @@ def generate_advertisement_data(
         platform_data=(),
     )
 
+
 def generate_ble_device(
-        address: str,
-        name: str | None = None,
+    address: str,
+    name: str | None = None,
 ) -> BLEDevice:
     """Generate a BLE device for testing."""
     return BLEDevice(
@@ -77,16 +76,18 @@ def generate_ble_device(
         details={},
     )
 
+
 def inject_bluetooth_service_info(
-        hass: HomeAssistant, info: BluetoothServiceInfo
+    hass: HomeAssistant, info: BluetoothServiceInfo
 ) -> None:
     """mock injection of service info."""
     return
 
+
 async def get_diagnostics_for_config_entry(
-        hass: HomeAssistant,
-        hass_client: Callable[..., Coroutine[Any, Any, TestClient]],
-        config_entry: ConfigEntry,
+    hass: HomeAssistant,
+    hass_client: Callable[..., Coroutine[Any, Any, TestClient]],
+    config_entry: ConfigEntry,
 ) -> dict[str, str]:
     """Return the diagnostics config entry for the specified domain."""
     return {}


### PR DESCRIPTION
## Summary
- Prefill password field with `HiLink` during LD2410 setup
- Test default password handling in config flow
- Provide local test utilities for config entries

## Testing
- `ruff check custom_components/ld2410/config_flow.py custom_components/ld2410/api/ld2410/adv_parser.py tests/mocks.py tests/test_config_flow.py tests/common.py --fix`
- `ruff format custom_components/ld2410/config_flow.py custom_components/ld2410/api/ld2410/adv_parser.py tests/mocks.py tests/test_config_flow.py tests/common.py`
- `pytest tests/test_config_flow.py`
- `pytest` *(fails: KeyError 'hubmini_matter')*
- `pytest tests/test_config_flow.py --cov=custom_components.ld2410`

------
https://chatgpt.com/codex/tasks/task_e_68a7aabaede083309396a7649a828726