### PR TITLE
Add workflow to run tests on merge to main

### DIFF
--- a/.github/workflows/test-on-merge.yml
+++ b/.github/workflows/test-on-merge.yml
@@ -1,0 +1,24 @@
+name: Run tests on merge to main
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.dev.txt
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          pytest


### PR DESCRIPTION
## Summary
- run tests in GitHub Actions when commits are pushed to `main`

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest` *(fails: Lingering task after test <Task pending name='Task-128' ... )*

## Coverage
- Test coverage percentage: unknown (tests failing)

------
https://chatgpt.com/codex/tasks/task_e_68aa14209d848330a7cbfb77d648959a