### PR TITLE
feat: include mac digits in discovery name

### DIFF
--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -46,7 +46,7 @@ def short_address(address: str) -> str:
 
 def name_from_discovery(discovery: LD2410Advertisement) -> str:
     """Get the name from a discovery."""
-    return f"{discovery.data['modelFriendlyName']} {short_address(discovery.address)}"
+    return f"LD2410_{short_address(discovery.address)}"
 
 
 class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -87,11 +87,7 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
             # Source is not connectable but the model is connectable
             return self.async_abort(reason="not_supported")
         self._discovered_adv = parsed
-        data = parsed.data
-        self.context["title_placeholders"] = {
-            "name": data["modelFriendlyName"],
-            "address": short_address(discovery_info.address),
-        }
+        self.context["title_placeholders"] = {"name": name_from_discovery(parsed)}
         return await self.async_step_password()
         return await self.async_step_confirm()
 

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "{name} ({address})",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "data": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -52,7 +52,7 @@ async def test_bluetooth_discovery_requires_password(hass: HomeAssistant) -> Non
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "HLK-LD2410 EEFF"
+    assert result["title"] == "LD2410_EEFF"
     assert result["data"] == {
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_SENSOR_TYPE: "ld2410",
@@ -129,7 +129,7 @@ async def test_user_setup_ld2410_replaces_ignored(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "HLK-LD2410 EEFF"
+    assert result["title"] == "LD2410_EEFF"
     assert result["data"] == {
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_SENSOR_TYPE: "ld2410",
@@ -205,7 +205,7 @@ async def test_async_step_user_takes_precedence_over_discovery(
         )
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "HLK-LD2410 EEFF"
+    assert result2["title"] == "LD2410_EEFF"
     assert result2["data"] == {
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_SENSOR_TYPE: "ld2410",


### PR DESCRIPTION
## Summary
- show LD2410_<MAC suffix> in discovery titles
- test adjustments for new discovery name

## Testing
- `ruff check . --fix`
- `ruff format custom_components/ld2410/config_flow.py custom_components/ld2410/strings.json tests/test_config_flow.py`
- `pytest` *(fails: KeyError: 'path', snapshot mismatch)*
- `pytest --maxfail=1 --cov=custom_components/ld2410` *(fails: AssertionError: snapshot)*

## Coverage
- `pytest --maxfail=1 --cov=custom_components/ld2410` -> 58%

------
https://chatgpt.com/codex/tasks/task_e_68aa2d869c70833090fc59c5fe439bb3