### PR TITLE
Add LD2410 error translations and update tests

### DIFF
--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -1,0 +1,16 @@
+{
+    "exceptions": {
+        "operation_error": {
+            "message": "An error occurred while performing the action: {error}"
+        },
+        "value_error": {
+            "message": "LD2410 device initialization failed because of incorrect configuration parameters: {error}"
+        },
+        "advertising_state_error": {
+            "message": "{address} is not advertising state"
+        },
+        "device_not_found_error": {
+            "message": "Could not find LD2410 {sensor_type} with address {address}"
+        }
+    }
+}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,13 +18,10 @@ except ImportError:
     from .mocks import MockConfigEntry
 
 try:
-    from tests.components.bluetooth import (
-        inject_bluetooth_service_info
-    )
+    from tests.components.bluetooth import inject_bluetooth_service_info
 except ImportError:
-    from .mocks import (
-        inject_bluetooth_service_info
-    )
+    from .mocks import inject_bluetooth_service_info
+
 
 @pytest.mark.parametrize(
     ("exception", "error_message"),
@@ -71,10 +68,7 @@ async def test_setup_entry_without_ble_device(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert (
-        "Could not find LD2410 hygrometer_co2 with address aa:bb:cc:dd:ee:ff"
-        in caplog.text
-    )
+    assert "Could not find LD2410 test with address AA:BB:CC:DD:EE:FF" in caplog.text
 
 
 async def test_coordinator_wait_ready_timeout(
@@ -100,4 +94,4 @@ async def test_coordinator_wait_ready_timeout(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert "aa:bb:cc:dd:ee:ff is not advertising state" in caplog.text
+    assert "AA:BB:CC:DD:EE:FF is not advertising state" in caplog.text


### PR DESCRIPTION
## Summary
- add English translations for LD2410 setup errors
- adjust init tests to match actual log messages

## Testing
- `ruff check tests/test_init.py --fix`
- `ruff format tests/test_init.py`
- `pytest tests/test_init.py -q`
- `pytest -q`
- `pytest --cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e6e55988330bc015d2053d3f590