### PR TITLE
Trim unused LD2410 entities and sensors

### DIFF
--- a/custom_components/ld2410/binary_sensor.py
+++ b/custom_components/ld2410/binary_sensor.py
@@ -7,7 +7,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 try:
@@ -30,16 +29,10 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
         name=None,
         device_class=BinarySensorDeviceClass.MOTION,
     ),
-    "contact_open": BinarySensorEntityDescription(
-        key="contact_open",
+    "presence_detected": BinarySensorEntityDescription(
+        key="presence_state",
         name=None,
-        device_class=BinarySensorDeviceClass.DOOR,
-    ),
-    "contact_timeout": BinarySensorEntityDescription(
-        key="contact_timeout",
-        translation_key="door_timeout",
-        device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PRESENCE,
     ),
 }
 

--- a/custom_components/ld2410/entity.py
+++ b/custom_components/ld2410/entity.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Coroutine, Mapping
 import logging
 from typing import Any, Concatenate
 
-from .api.ld2410 import LD2410, LD2410Device
+from .api.ld2410 import LD2410Device
 from .api.ld2410.devices.device import LD2410OperationError
 
 from homeassistant.components.bluetooth.passive_update_coordinator import (
@@ -17,7 +17,6 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import ToggleEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import LD2410DataUpdateCoordinator
@@ -107,29 +106,3 @@ def exception_handler[_EntityT: LD2410Entity, **_P](
             ) from error
 
     return handler
-
-
-class LD2410SwitchedEntity(LD2410Entity, ToggleEntity):
-    """Base class for LD2410 entities that can be turned on and off."""
-
-    _device: LD2410
-
-    @exception_handler
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn device on."""
-        _LOGGER.debug("Turn LD2410 device on %s", self._address)
-
-        self._last_run_success = bool(await self._device.turn_on())
-        if self._last_run_success:
-            self._attr_is_on = True
-        self.async_write_ha_state()
-
-    @exception_handler
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn device off."""
-        _LOGGER.debug("Turn LD2410 device off %s", self._address)
-
-        self._last_run_success = bool(await self._device.turn_off())
-        if self._last_run_success:
-            self._attr_is_on = False
-        self.async_write_ha_state()

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -10,16 +10,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
-    LIGHT_LUX,
-    PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
-    UnitOfElectricCurrent,
-    UnitOfElectricPotential,
-    UnitOfEnergy,
-    UnitOfPower,
-    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 
@@ -47,75 +39,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    "wifi_rssi": SensorEntityDescription(
-        key="wifi_rssi",
-        translation_key="wifi_signal",
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    "battery": SensorEntityDescription(
-        key="battery",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    "co2": SensorEntityDescription(
-        key="co2",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CO2,
-    ),
-    "lightLevel": SensorEntityDescription(
-        key="lightLevel",
-        translation_key="light_level",
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    "humidity": SensorEntityDescription(
-        key="humidity",
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.HUMIDITY,
-    ),
-    "illuminance": SensorEntityDescription(
-        key="illuminance",
-        native_unit_of_measurement=LIGHT_LUX,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.ILLUMINANCE,
-    ),
-    "temperature": SensorEntityDescription(
-        key="temperature",
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.TEMPERATURE,
-    ),
-    "power": SensorEntityDescription(
-        key="power",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.POWER,
-    ),
-    "current": SensorEntityDescription(
-        key="current",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CURRENT,
-    ),
-    "voltage": SensorEntityDescription(
-        key="voltage",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-    ),
-    "energy": SensorEntityDescription(
-        key="energy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-    ),
     "firmware_version": SensorEntityDescription(
         key="firmware_version",
         name="Firmware version",
@@ -140,7 +63,7 @@ async def async_setup_entry(
     entities = [
         LD2410Sensor(coordinator, sensor)
         for sensor in coordinator.device.parsed_data
-        if sensor in SENSOR_TYPES
+        if sensor in SENSOR_TYPES and sensor != "rssi"
     ]
     entities.append(LD2410RSSISensor(coordinator, "rssi"))
     async_add_entities(entities)


### PR DESCRIPTION
## Summary
- drop unused LD2410SwitchedEntity class
- expose only motion and presence binary sensors
- limit sensor entities to RSSI and firmware details

## Reasoning
These changes remove unused entities and attributes so the integration only exposes functionality that is supported today, keeping the codebase leaner and easier to maintain.

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410` (64% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68aa3d07bdf0833096aa3b9963ae265c