### PR TITLE
Remove obsolete HTTP API helper

### DIFF
--- a/custom_components/ld2410/api/ld2410/api_config.py
+++ b/custom_components/ld2410/api/ld2410/api_config.py
@@ -1,6 +1,0 @@
-# Those values have been obtained from the following files in LD2410 Android app
-# That's how you can verify them yourself
-# /assets/ld2410_config.json
-
-LD2410_APP_API_BASE_URL = "api.ld2410.net"
-LD2410_APP_CLIENT_ID = "5nnwmhmsa9xxskm14hd85lm9bm"

--- a/custom_components/ld2410/api/requirements.txt
+++ b/custom_components/ld2410/api/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp>=3.9.5
 bleak>=0.17.0
 bleak-retry-connector>=2.9.0
 cryptography>=38.0.3

--- a/custom_components/ld2410/api/requirements_dev.txt
+++ b/custom_components/ld2410/api/requirements_dev.txt
@@ -1,6 +1,5 @@
 pytest-asyncio
 pytest-cov
-aiohttp>=3.9.5
 bleak>=0.17.0
 bleak-retry-connector>=3.4.0
 cryptography>=38.0.3

--- a/custom_components/ld2410/api/setup.py
+++ b/custom_components/ld2410/api/setup.py
@@ -14,7 +14,6 @@ setup(
         "ld2410.adv_parsers",
     ],
     install_requires=[
-        "aiohttp>=3.9.5",
         "bleak>=0.19.0",
         "bleak-retry-connector>=3.4.0",
         "cryptography>=39.0.0",


### PR DESCRIPTION
## Summary
- drop unused API request helper from LD2410 device
- remove obsolete `api_config` module
- eliminate `aiohttp` from package requirements

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a86acb88330a2e83d063157dee1