### PR TITLE
Rename LD2410 modules to descriptive names

### DIFF
--- a/custom_components/ld2410/api/__init__.py
+++ b/custom_components/ld2410/api/__init__.py
@@ -19,9 +19,7 @@ from .const import (
     LD2410Model,
 )
 from .devices.device import LD2410Device, LD2410OperationError
-from .devices.ld2410 import (
-    LD2410,
-)
+from .devices.device_control import LD2410
 from .discovery import GetLD2410Devices
 from .models import LD2410Advertisement
 

--- a/custom_components/ld2410/api/adv_parser.py
+++ b/custom_components/ld2410/api/adv_parser.py
@@ -10,7 +10,7 @@ from typing import Any, TypedDict
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
-from .adv_parsers.ld2410 import process_ld2410
+from .adv_parsers.firmware_parser import parse_firmware_data
 from .const import LD2410Model
 from .models import LD2410Advertisement
 
@@ -34,7 +34,7 @@ SUPPORTED_TYPES: dict[str | bytes, LD2410SupportedType] = {
     "t": {
         "modelName": LD2410Model.LD2410,
         "modelFriendlyName": "HLK-LD2410",
-        "func": process_ld2410,
+        "func": parse_firmware_data,
         "manufacturer_id": 256,
     },
 }

--- a/custom_components/ld2410/api/adv_parsers/firmware_parser.py
+++ b/custom_components/ld2410/api/adv_parsers/firmware_parser.py
@@ -1,4 +1,4 @@
-"""LD2410 parser."""
+"""Parse manufacturer firmware data for the LD2410 sensor."""
 
 from __future__ import annotations
 
@@ -15,10 +15,10 @@ def _bcd_str(byte: int) -> str:
     return f"{byte >> 4}{byte & 0x0F}"
 
 
-def process_ld2410(
+def parse_firmware_data(
     data: bytes | None, mfr_data: bytes | None
 ) -> dict[str, bool | int | str | datetime]:
-    """Process LD2410 manufacturer data."""
+    """Return firmware details extracted from manufacturer data."""
     if not mfr_data or len(mfr_data) < 13:
         return {}
 

--- a/custom_components/ld2410/api/devices/device_control.py
+++ b/custom_components/ld2410/api/devices/device_control.py
@@ -1,4 +1,4 @@
-"""Library to handle connection with Switchbot."""
+"""Control commands for the LD2410 device."""
 
 from __future__ import annotations
 
@@ -14,21 +14,21 @@ from .device import (
 
 _LOGGER = logging.getLogger(__name__)
 
-BOT_COMMAND_HEADER = "5701"
+DEVICE_COMMAND_HEADER = "5701"
 
-# Bot keys
-PRESS_KEY = f"{BOT_COMMAND_HEADER}00"
-ON_KEY = f"{BOT_COMMAND_HEADER}01"
-OFF_KEY = f"{BOT_COMMAND_HEADER}02"
-DOWN_KEY = f"{BOT_COMMAND_HEADER}03"
-UP_KEY = f"{BOT_COMMAND_HEADER}04"
+# Device command keys
+PRESS_KEY = f"{DEVICE_COMMAND_HEADER}00"
+ON_KEY = f"{DEVICE_COMMAND_HEADER}01"
+OFF_KEY = f"{DEVICE_COMMAND_HEADER}02"
+DOWN_KEY = f"{DEVICE_COMMAND_HEADER}03"
+UP_KEY = f"{DEVICE_COMMAND_HEADER}04"
 
 
 class LD2410(LD2410Device):
-    """Representation of a LD2410."""
+    """Representation of an LD2410 device."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """LD2410 Bot/WoHand constructor."""
+        """Initialize the device control class."""
         super().__init__(*args, **kwargs)
         self._inverse: bool = kwargs.pop("inverse_mode", False)
 
@@ -84,7 +84,7 @@ class LD2410(LD2410Device):
     async def set_switch_mode(
         self, switch_mode: bool = False, strength: int = 100, inverse: bool = False
     ) -> bool:
-        """Change bot mode."""
+        """Change device mode."""
         mode_key = format(switch_mode, "b") + format(inverse, "b")
         strength_key = f"{strength:0{2}x}"  # to hex with padding to double digit
         result = await self._send_command(DEVICE_SET_MODE_KEY + strength_key + mode_key)
@@ -92,7 +92,7 @@ class LD2410(LD2410Device):
 
     @update_after_operation
     async def set_long_press(self, duration: int = 0) -> bool:
-        """Set bot long press duration."""
+        """Set device long press duration."""
         duration_key = f"{duration:0{2}x}"  # to hex with padding to double digit
         result = await self._send_command(DEVICE_SET_EXTENDED_KEY + "08" + duration_key)
         return self._check_command_result(result, 0, {1})


### PR DESCRIPTION
## Summary
- rename advertisement manufacturer parser to firmware_parser and clarify function name
- rename device implementation file to device_control with device-focused terminology
- update imports to use new module names

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov`

## Coverage
- 64%


------
https://chatgpt.com/codex/tasks/task_e_68aaf75acf2883308aeaf7c224e16551