### PR TITLE
Rename LD2410 entity classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
   pytest
   ```
 - Run tests and linters for every code change.
+- Snapshots should be kept under the `tests/__snapshots__` folder.
 
 ## Pull request rules
 - The pull request description must include:

--- a/custom_components/ld2410/binary_sensor.py
+++ b/custom_components/ld2410/binary_sensor.py
@@ -19,7 +19,7 @@ except ImportError:  # Home Assistant <2024.6
     )
 
 from .coordinator import ConfigEntryType, DataCoordinator
-from .entity import LD2410Entity
+from .entity import Entity
 
 PARALLEL_UPDATES = 0
 
@@ -51,7 +51,7 @@ async def async_setup_entry(
     )
 
 
-class LD2410BinarySensor(LD2410Entity, BinarySensorEntity):
+class LD2410BinarySensor(Entity, BinarySensorEntity):
     """Representation of a LD2410 binary sensor."""
 
     def __init__(

--- a/custom_components/ld2410/entity.py
+++ b/custom_components/ld2410/entity.py
@@ -23,8 +23,8 @@ from .coordinator import DataCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-class LD2410Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
-    """Generic entity encapsulating common features of LD2410 device."""
+class Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
+    """Generic entity encapsulating common features of an LD2410 device."""
 
     _device: Device
     _attr_has_entity_name = True
@@ -86,7 +86,7 @@ class LD2410Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
         await self._device.update()
 
 
-def exception_handler[_EntityT: LD2410Entity, **_P](
+def exception_handler[_EntityT: Entity, **_P](
     func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate LD2410 calls to handle exceptions..

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -25,7 +25,7 @@ except ImportError:  # Home Assistant <2024.6
     )
 
 from .coordinator import ConfigEntryType, DataCoordinator
-from .entity import LD2410Entity
+from .entity import Entity
 
 PARALLEL_UPDATES = 0
 
@@ -61,15 +61,15 @@ async def async_setup_entry(
     """Set up LD2410 sensor based on a config entry."""
     coordinator = entry.runtime_data
     entities = [
-        LD2410Sensor(coordinator, sensor)
+        Sensor(coordinator, sensor)
         for sensor in coordinator.device.parsed_data
         if sensor in SENSOR_TYPES and sensor != "rssi"
     ]
-    entities.append(LD2410RSSISensor(coordinator, "rssi"))
+    entities.append(RSSISensor(coordinator, "rssi"))
     async_add_entities(entities)
 
 
-class LD2410Sensor(LD2410Entity, SensorEntity):
+class Sensor(Entity, SensorEntity):
     """Representation of a LD2410 sensor."""
 
     def __init__(
@@ -89,7 +89,7 @@ class LD2410Sensor(LD2410Entity, SensorEntity):
         return self.parsed_data[self._sensor]
 
 
-class LD2410RSSISensor(LD2410Sensor):
+class RSSISensor(Sensor):
     """Representation of a LD2410 RSSI sensor."""
 
     @property


### PR DESCRIPTION
## Summary
- rename LD2410Entity to Entity
- update sensors and binary sensors to inherit from the new Entity base
- rename LD2410Sensor to Sensor and LD2410RSSISensor to RSSISensor
- keep diagnostics snapshot in `tests/__snapshots__` and document snapshot location

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`

## Test Coverage
66%


------
https://chatgpt.com/codex/tasks/task_e_68ab09d8739c8330b019d12488bca633