### PR TITLE
refactor: generalize device references

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -1,4 +1,4 @@
-"""Support for LD2410 devices."""
+"""Support for devices."""
 
 import logging
 
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool:
-    """Set up LD2410 from a config entry."""
+    """Set up the device from a config entry."""
     assert entry.unique_id is not None
     if CONF_ADDRESS not in entry.data and CONF_MAC in entry.data:
         # Bleak uses addresses not mac addresses which are actually

--- a/custom_components/ld2410/api/__init__.py
+++ b/custom_components/ld2410/api/__init__.py
@@ -1,4 +1,4 @@
-"""Library to handle connection with LD2410."""
+"""Library to handle device connection."""
 
 from __future__ import annotations
 

--- a/custom_components/ld2410/api/adv_parser.py
+++ b/custom_components/ld2410/api/adv_parser.py
@@ -1,4 +1,4 @@
-"""LD2410 advertisement parser."""
+"""Advertisement parser."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ MFR_DATA_ORDER = (256, 1494)
 
 
 class SupportedType(TypedDict):
-    """Supported type of LD2410."""
+    """Supported device type."""
 
     modelName: Model
     modelFriendlyName: str

--- a/custom_components/ld2410/api/adv_parsers/__init__.py
+++ b/custom_components/ld2410/api/adv_parsers/__init__.py
@@ -1,1 +1,1 @@
-"""LD2410 Advertisement Parser Library."""
+"""Advertisement parser library."""

--- a/custom_components/ld2410/api/adv_parsers/firmware_parser.py
+++ b/custom_components/ld2410/api/adv_parsers/firmware_parser.py
@@ -1,4 +1,4 @@
-"""Parse manufacturer firmware data for the LD2410 sensor."""
+"""Parse manufacturer firmware data for the device."""
 
 from __future__ import annotations
 

--- a/custom_components/ld2410/api/const/__init__.py
+++ b/custom_components/ld2410/api/const/__init__.py
@@ -1,4 +1,4 @@
-"""LD2410 Device Consts Library."""
+"""Device constants library."""
 
 from __future__ import annotations
 
@@ -69,7 +69,7 @@ engineering_frame_regex = (
 
 
 class Model(StrEnum):
-    """LD2410 device models."""
+    """Device models."""
 
     LD2410 = "HLK-LD2410B"
 

--- a/custom_components/ld2410/api/devices/__init__.py
+++ b/custom_components/ld2410/api/devices/__init__.py
@@ -1,1 +1,1 @@
-"""LD2410 Device Library."""
+"""Device library."""

--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -1,4 +1,4 @@
-"""Library to handle connection with LD2410."""
+"""Library to handle device connection."""
 
 from __future__ import annotations
 
@@ -693,7 +693,7 @@ class BaseDevice:
 
 
 class Device(BaseDevice):
-    """Representation of an LD2410 device."""
+    """Representation of a device."""
 
     def update_from_advertisement(self, advertisement: Advertisement) -> None:
         """Update device data from advertisement."""

--- a/custom_components/ld2410/api/devices/device_control.py
+++ b/custom_components/ld2410/api/devices/device_control.py
@@ -1,4 +1,4 @@
-"""Control commands for the LD2410 device."""
+"""Control commands for the device."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ UP_KEY = f"{DEVICE_COMMAND_HEADER}04"
 
 
 class LD2410(Device):
-    """Representation of an LD2410 device."""
+    """Representation of a device."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the device control class."""

--- a/custom_components/ld2410/api/discovery.py
+++ b/custom_components/ld2410/api/discovery.py
@@ -1,4 +1,4 @@
-"""Discover ld2410 devices."""
+"""Discover devices."""
 
 from __future__ import annotations
 
@@ -18,10 +18,10 @@ CONNECT_LOCK = asyncio.Lock()
 
 
 class GetDevices:
-    """Scan for all LD2410 devices and return by type."""
+    """Scan for all devices and return by type."""
 
     def __init__(self, interface: int = 0) -> None:
-        """Get ld2410 devices class constructor."""
+        """Get devices class constructor."""
         self._interface = f"hci{interface}"
         self._adv_data: dict[str, Advertisement] = {}
 
@@ -38,7 +38,7 @@ class GetDevices:
     async def discover(
         self, retry: int = DEFAULT_RETRY_COUNT, scan_timeout: int = DEFAULT_SCAN_TIMEOUT
     ) -> dict[str, Advertisement]:
-        """Find ld2410 devices and their advertisement data."""
+        """Find devices and their advertisement data."""
         devices = bleak.BleakScanner(
             detection_callback=self.detection_callback,
             adapter=self._interface,
@@ -69,7 +69,7 @@ class GetDevices:
         self,
         model: str,
     ) -> dict[str, Advertisement]:
-        """Get ld2410 devices by type."""
+        """Get devices by type."""
         if not self._adv_data:
             await self.discover()
 

--- a/custom_components/ld2410/api/models.py
+++ b/custom_components/ld2410/api/models.py
@@ -1,4 +1,4 @@
-"""Library to handle connection with LD2410."""
+"""Library to handle device connection."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from bleak.backends.device import BLEDevice
 
 @dataclass
 class Advertisement:
-    """Advertisement from an LD2410 device."""
+    """Advertisement from a device."""
 
     address: str
     data: dict[str, Any]

--- a/custom_components/ld2410/binary_sensor.py
+++ b/custom_components/ld2410/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Support for LD2410 binary sensors."""
+"""Support for binary sensors."""
 
 from __future__ import annotations
 
@@ -42,24 +42,24 @@ async def async_setup_entry(
     entry: ConfigEntryType,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up LD2410 curtain based on a config entry."""
+    """Set up binary sensors based on a config entry."""
     coordinator = entry.runtime_data
     async_add_entities(
-        LD2410BinarySensor(coordinator, binary_sensor)
+        BinarySensor(coordinator, binary_sensor)
         for binary_sensor in coordinator.device.parsed_data
         if binary_sensor in BINARY_SENSOR_TYPES
     )
 
 
-class LD2410BinarySensor(Entity, BinarySensorEntity):
-    """Representation of a LD2410 binary sensor."""
+class BinarySensor(Entity, BinarySensorEntity):
+    """Representation of a binary sensor."""
 
     def __init__(
         self,
         coordinator: DataCoordinator,
         binary_sensor: str,
     ) -> None:
-        """Initialize the LD2410 sensor."""
+        """Initialize the sensor."""
         super().__init__(coordinator)
         self._sensor = binary_sensor
         self._attr_unique_id = f"{coordinator.base_unique_id}-{binary_sensor}"

--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for LD2410."""
+"""Config flow."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def format_unique_id(address: str) -> str:
-    """Format the unique ID for a ld2410."""
+    """Format the unique ID for a device."""
     return address.replace(":", "").lower()
 
 
@@ -49,7 +49,7 @@ def name_from_discovery(discovery: Advertisement) -> str:
 
 
 class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for LD2410."""
+    """Handle a config flow."""
 
     VERSION = 1
 
@@ -211,12 +211,12 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class LD2410OptionsFlowHandler(OptionsFlow):
-    """Handle LD2410 options."""
+    """Handle options."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Manage LD2410 options."""
+        """Manage options."""
         if user_input is not None:
             # Update common entity options for all other entities.
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/ld2410/const.py
+++ b/custom_components/ld2410/const.py
@@ -1,4 +1,4 @@
-"""Constants for the ld2410 integration."""
+"""Constants for the integration."""
 
 from enum import StrEnum
 
@@ -13,7 +13,7 @@ DEFAULT_NAME = "LD2410"
 
 
 class SupportedModels(StrEnum):
-    """Supported LD2410 models."""
+    """Supported models."""
 
     LD2410 = "ld2410"
 

--- a/custom_components/ld2410/coordinator.py
+++ b/custom_components/ld2410/coordinator.py
@@ -1,4 +1,4 @@
-"""Provides the ld2410 DataUpdateCoordinator."""
+"""Provides the data update coordinator."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ DEVICE_STARTUP_TIMEOUT = 30
 
 
 class DataCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
-    """Class to manage fetching ld2410 data."""
+    """Class to manage fetching device data."""
 
     def __init__(
         self,
@@ -40,7 +40,7 @@ class DataCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
         connectable: bool,
         model: Model,
     ) -> None:
-        """Initialize global ld2410 data updater."""
+        """Initialize the global data updater."""
         super().__init__(
             hass=hass,
             logger=logger,

--- a/custom_components/ld2410/entity.py
+++ b/custom_components/ld2410/entity.py
@@ -1,4 +1,4 @@
-"""An abstract class common to all LD2410 entities."""
+"""An abstract class common to all entities."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
-    """Generic entity encapsulating common features of an LD2410 device."""
+    """Generic entity encapsulating common features of a device."""
 
     _device: Device
     _attr_has_entity_name = True
@@ -89,9 +89,9 @@ class Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
 def exception_handler[_EntityT: Entity, **_P](
     func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
-    """Decorate LD2410 calls to handle exceptions..
+    """Decorate device calls to handle exceptions.
 
-    A decorator that wraps the passed in function, catches LD2410 errors.
+    A decorator that wraps the passed in function, catching device errors.
     """
 
     async def handler(self: _EntityT, *args: _P.args, **kwargs: _P.kwargs) -> None:

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -1,4 +1,4 @@
-"""Support for LD2410 sensors."""
+"""Support for sensors."""
 
 from __future__ import annotations
 
@@ -58,7 +58,7 @@ async def async_setup_entry(
     entry: ConfigEntryType,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up LD2410 sensor based on a config entry."""
+    """Set up sensors based on a config entry."""
     coordinator = entry.runtime_data
     entities = [
         Sensor(coordinator, sensor)
@@ -70,14 +70,14 @@ async def async_setup_entry(
 
 
 class Sensor(Entity, SensorEntity):
-    """Representation of a LD2410 sensor."""
+    """Representation of a sensor."""
 
     def __init__(
         self,
         coordinator: DataCoordinator,
         sensor: str,
     ) -> None:
-        """Initialize the LD2410 sensor."""
+        """Initialize the sensor."""
         super().__init__(coordinator)
         self._sensor = sensor
         self._attr_unique_id = f"{coordinator.base_unique_id}-{sensor}"
@@ -90,12 +90,12 @@ class Sensor(Entity, SensorEntity):
 
 
 class RSSISensor(Sensor):
-    """Representation of a LD2410 RSSI sensor."""
+    """Representation of a RSSI sensor."""
 
     @property
     def native_value(self) -> str | int | None:
         """Return the state of the sensor."""
-        # LD2410 supports both connectable and non-connectable devices
+        # The device supports both connectable and non-connectable devices
         # so we need to request the rssi value based on the connectable instead
         # of the nearest scanner since that is the RSSI that matters for controlling
         # the device.

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -1,0 +1,27 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'entry': dict({
+      'data': dict({
+        'address': 'AA:BB:CC:DD:EE:FF',
+        'name': 'test-name',
+        'sensor_type': 'ld2410',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'ld2410',
+      'minor_version': 1,
+      'options': dict({
+        'retry_count': 3,
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'Mock Title',
+      'unique_id': 'aabbccddeeff',
+      'version': 1,
+    }),
+    'service_info': <BluetoothServiceInfoBleak name=HLK-LD2410_96D8 address=AA:BB:CC:DD:EE:FF rssi=-90 manufacturer_data={256: b'D\x02\x101\x07$\x00\xaa\xbb\xcc\xdd\xee\xff', 1494: b'\x08\x00JLAISDK'} service_data={} service_uuids=['0000af30-0000-1000-8000-00805f9b34fb'] source=local connectable=True time=0.0 tx_power=-127 raw=None>,
+  })
+# ---

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for the diagnostics data provided by the LD2410 integration."""
+"""Tests for the diagnostics data provided by the integration."""
 
 from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- rename `LD2410BinarySensor` to `BinarySensor`
- generalize docstrings to refer to generic devices and sensors
- adjust tests to use new naming

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68ab116ce25083308b6c37678e52a2a1