### PR TITLE
Return boolean from bluetooth password command

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -9,7 +9,6 @@ from ..const import CMD_BT_GET_PERMISSION
 from .device import (
     Device,
     OperationError,
-    update_after_operation,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,8 +33,11 @@ class LD2410(Device):
 
     async def cmd_send_bluetooth_password(
         self, words: Sequence[str] | None = None
-    ) -> bytes | None:
-        """Send the bluetooth password to the device."""
+    ) -> bool:
+        """Send the bluetooth password to the device.
+
+        Returns True if the password is accepted.
+        """
         payload_words = words or self._password_words
         if not payload_words:
             raise OperationError("Password required")
@@ -44,7 +46,7 @@ class LD2410(Device):
         response = await self._send_command(key)
         if response == b"\x01\x00":
             raise OperationError("Wrong password")
-        return response
+        return response == b"\x00\x00"
 
     async def get_basic_info(self) -> dict[str, Any] | None:
         """Get device basic settings."""

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -48,7 +48,7 @@ class _TestDevice(LD2410):
 async def test_send_bluetooth_password_uses_config_password() -> None:
     """Ensure the device uses the configured password when none provided."""
     dev = _TestDevice(password="HiLink")
-    await dev.cmd_send_bluetooth_password()
+    assert await dev.cmd_send_bluetooth_password()
     assert dev.last_key == CMD_BT_GET_PERMISSION + "".join(_password_to_words("HiLink"))
 
 


### PR DESCRIPTION
## Summary
- return boolean from `cmd_send_bluetooth_password`
- adjust device command test for boolean return

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410`

## Coverage
- 69%


------
https://chatgpt.com/codex/tasks/task_e_68ab5702a4cc8330a59c3e22e41a3105