### PR TITLE
Move intra-frame parser into LD2410 device

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence
+from typing import Any, Dict, Sequence
 
 from ..const import CMD_BT_GET_PERMISSION
 from .device import (
@@ -21,6 +21,93 @@ ON_KEY = f"{DEVICE_COMMAND_HEADER}01"
 OFF_KEY = f"{DEVICE_COMMAND_HEADER}02"
 DOWN_KEY = f"{DEVICE_COMMAND_HEADER}03"
 UP_KEY = f"{DEVICE_COMMAND_HEADER}04"
+
+
+_STATUS_MAP = {
+    0x00: "no_target",
+    0x01: "moving",
+    0x02: "stationary",
+    0x03: "moving_and_stationary",
+}
+
+
+def parse_intra_frame(data: bytes) -> Dict[str, Any] | None:
+    """Parse an uplink intra frame.
+
+    ``data`` must be the payload after removing the frame header and footer
+    (the length field should also be stripped). The payload is expected to
+    start with the frame type byte followed by ``0xAA`` and end with ``55 00``.
+    """
+    if len(data) < 2 or data[1] != 0xAA:
+        return None
+
+    frame_type = data[0]
+    if frame_type == 0x01:
+        ftype = "engineering"
+    elif frame_type == 0x02:
+        ftype = "basic"
+    else:
+        return None
+
+    if not data.endswith(b"\x55\x00"):
+        return None
+
+    idx = 2  # skip type and 0xAA
+    content = data[idx:-2]
+
+    # Basic fields
+    if len(content) < 9:
+        return None
+    status_raw = content[0]
+    move_distance_cm = int.from_bytes(content[1:3], "little")
+    move_energy = content[3]
+    still_distance_cm = int.from_bytes(content[4:6], "little")
+    still_energy = content[6]
+    detect_distance_cm = int.from_bytes(content[7:9], "little")
+    idx = 9
+
+    status = _STATUS_MAP.get(status_raw, "no_target")
+    moving = status_raw in (0x01, 0x03)
+    stationary = status_raw in (0x02, 0x03)
+    presence = moving or stationary
+
+    result: Dict[str, Any] = {
+        "type": ftype,
+        "status": status,
+        "moving": moving,
+        "stationary": stationary,
+        "presence": presence,
+        "move_distance_cm": move_distance_cm,
+        "move_energy": move_energy,
+        "still_distance_cm": still_distance_cm,
+        "still_energy": still_energy,
+        "detect_distance_cm": detect_distance_cm,
+    }
+
+    if ftype == "engineering":
+        if len(content) < idx + 2:
+            return None
+        max_move_gate = content[idx]
+        max_still_gate = content[idx + 1]
+        idx += 2
+        move_len = max_move_gate + 1
+        still_len = max_still_gate + 1
+        if len(content) < idx + move_len + still_len:
+            return None
+        move_gate_energy = list(content[idx : idx + move_len])
+        idx += move_len
+        still_gate_energy = list(content[idx : idx + still_len])
+        idx += still_len
+        result.update(
+            {
+                "max_move_gate": max_move_gate,
+                "max_still_gate": max_still_gate,
+                "move_gate_energy": move_gate_energy,
+                "still_gate_energy": still_gate_energy,
+            }
+        )
+
+    return result
 
 
 class LD2410(Device):
@@ -49,15 +136,9 @@ class LD2410(Device):
         return response == b"\x00\x00"
 
     async def get_basic_info(self) -> dict[str, Any] | None:
-        """Get device basic settings."""
-        if not (_data := await self._get_basic_info()):
-            return None
-        return {
-            "battery": _data[1],
-            "firmware": _data[2] / 10.0,
-            "strength": _data[3],
-            "timers": _data[8],
-            "switchMode": bool(_data[9] & 16),
-            "inverseDirection": bool(_data[9] & 1),
-            "holdSeconds": _data[10],
-        }
+        """Return cached device data."""
+        return self.parsed_data or None
+
+    def parse_intra_frame(self, data: bytes) -> Dict[str, Any] | None:
+        """Parse an uplink intra frame."""
+        return parse_intra_frame(data)

--- a/tests/test_intra_parser.py
+++ b/tests/test_intra_parser.py
@@ -1,0 +1,80 @@
+"""Tests for intra frame parser and notification handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from bleak.backends.device import BLEDevice
+
+from custom_components.ld2410.api.devices.ld2410 import LD2410, parse_intra_frame
+from custom_components.ld2410.api.const import RX_HEADER, RX_FOOTER
+from custom_components.ld2410.api.models import Advertisement
+
+
+def test_parse_intra_frame_basic() -> None:
+    """Ensure basic intra frames are parsed correctly."""
+    payload = bytes.fromhex("02aa0101001402002803005500")
+    result = parse_intra_frame(payload)
+    assert result == {
+        "type": "basic",
+        "status": "moving",
+        "moving": True,
+        "stationary": False,
+        "presence": True,
+        "move_distance_cm": 1,
+        "move_energy": 20,
+        "still_distance_cm": 2,
+        "still_energy": 40,
+        "detect_distance_cm": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_notification_handler_engineering_frame_updates_data() -> None:
+    """Ensure engineering intra frames update device data and cache."""
+    payload_hex = (
+        "01aa034e00334e00643e000808123318050403050306000064202627190f1501015500"
+    )
+    payload = bytes.fromhex(payload_hex)
+    length = len(payload).to_bytes(2, "little").hex()
+    frame_hex = RX_HEADER + length + payload_hex + RX_FOOTER
+
+    device = LD2410(
+        device=BLEDevice(address="AA:BB", name="test", details=None, rssi=-60)
+    )
+    advertisement = Advertisement(
+        address="AA:BB",
+        data={"data": {}},
+        device=device._device,
+        rssi=-60,
+    )
+    device.update_from_advertisement(advertisement)
+
+    called = False
+
+    def _cb() -> None:
+        nonlocal called
+        called = True
+
+    device.subscribe(_cb)
+    device._notification_handler(0, bytearray.fromhex(frame_hex))
+
+    expected = {
+        "type": "engineering",
+        "status": "moving_and_stationary",
+        "moving": True,
+        "stationary": True,
+        "presence": True,
+        "move_distance_cm": 78,
+        "move_energy": 51,
+        "still_distance_cm": 78,
+        "still_energy": 100,
+        "detect_distance_cm": 62,
+        "max_move_gate": 8,
+        "max_still_gate": 8,
+        "move_gate_energy": [18, 51, 24, 5, 4, 3, 5, 3, 6],
+        "still_gate_energy": [0, 0, 100, 32, 38, 39, 25, 15, 21],
+    }
+    assert device.parsed_data == expected
+    assert called
+    assert await device.get_basic_info() == expected


### PR DESCRIPTION
## Summary
- relocate intra-frame parser into `devices/ld2410.py` and expose via the LD2410 class
- teach `BaseDevice` to delegate uplink frame parsing to device-specific implementation
- adjust tests to use the new parser location

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`

Coverage: 70%


------
https://chatgpt.com/codex/tasks/task_e_68abb4ea8c248330b7e8a40fa29fdca8