### PR TITLE
Ensure LD2410 BLE devices disconnect on unload

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -126,6 +126,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     sensor_type = entry.data[CONF_SENSOR_TYPE]
+    await entry.runtime_data.device.async_disconnect()
     return await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS_BY_TYPE[sensor_type]
     )


### PR DESCRIPTION
## Summary
- disconnect device before unloading config entry
- add async_disconnect to device API to stop notifications and close BLE client
- test unload disconnection behavior

## Testing
- `ruff check custom_components/ld2410/__init__.py custom_components/ld2410/api/devices/device.py tests/test_init.py`
- `ruff format custom_components/ld2410/__init__.py custom_components/ld2410/api/devices/device.py tests/test_init.py`
- `pytest tests/test_init.py tests/test_sensor.py`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 73%


------
https://chatgpt.com/codex/tasks/task_e_68aca80fd040833081c354acbb6a30d7