### PR TITLE
Add frame type diagnostic sensor

### DIFF
--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -51,6 +51,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "type": SensorEntityDescription(
+        key="type",
+        name="Frame type",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     "move_distance": SensorEntityDescription(
         key="move_distance_cm",
         name="Moving distance",


### PR DESCRIPTION
## Summary
- expose radar frame type (basic or engineering) via a new diagnostic sensor
- test that the frame type sensor is disabled by default

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- `75%`


------
https://chatgpt.com/codex/tasks/task_e_68acc2d31d84833081fb8bf09306109a