### PR TITLE
Schedule reconnect after timed disconnect

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -45,6 +45,11 @@ class LD2410(Device):
         except Exception as ex:  # pragma: no cover - best effort
             _LOGGER.debug("%s: Reconnect failed: %s", self.name, ex)
 
+    async def _execute_timed_disconnect(self) -> None:
+        """Execute timed disconnection and schedule reconnect."""
+        await super()._execute_timed_disconnect()
+        self.loop.create_task(self._restart_connection())
+
     async def cmd_send_bluetooth_password(
         self, words: Sequence[str] | None = None
     ) -> bool:

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -22,3 +22,18 @@ async def test_reconnect_after_unexpected_disconnect():
 
     device._ensure_connected.assert_awaited_once()
     device.cmd_send_bluetooth_password.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_after_timed_disconnect():
+    """Ensure device reconnects after a timed disconnect."""
+    device = LD2410(
+        device=BLEDevice(address="AA:BB", name="test", details=None, rssi=-60),
+        password="HiLink",
+    )
+    device._restart_connection = AsyncMock()
+
+    await device._execute_timed_disconnect()
+    await asyncio.sleep(0)
+
+    device._restart_connection.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ensure timed disconnects trigger reconnect
- test reconnect behavior after timed disconnect

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68acc6c47a5c8330b3f4ca66eabc2718