### PR TITLE
Mock Bluetooth connection in tests

### DIFF
--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -52,6 +52,10 @@ async def test_entities_stay_available_with_intra_frames(hass: HomeAssistant) ->
             "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
             AsyncMock(),
         ),
+        patch(
+            "custom_components.ld2410.api.LD2410.connect_and_subscribe",
+            AsyncMock(),
+        ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -16,6 +16,9 @@ async def test_reconnect_after_unexpected_disconnect():
     )
     device._ensure_connected = AsyncMock()
     device.cmd_send_bluetooth_password = AsyncMock()
+    device.cmd_enable_config = AsyncMock()
+    device.cmd_enable_engineering_mode = AsyncMock()
+    device.cmd_end_config = AsyncMock()
 
     device._disconnected(None)
     await asyncio.sleep(0)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -133,6 +133,22 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
             AsyncMock(),
         ) as mock_send,
+        patch(
+            "custom_components.ld2410.api.devices.device.Device._ensure_connected",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_config",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_end_config",
+            AsyncMock(),
+        ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -160,6 +176,22 @@ async def test_unload_disconnects_device(hass: HomeAssistant) -> None:
         patch("custom_components.ld2410.api.close_stale_connections_by_address"),
         patch(
             "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device._ensure_connected",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_config",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_end_config",
             AsyncMock(),
         ),
     ):


### PR DESCRIPTION
## Summary
- mock connect_and_subscribe in availability test to avoid real BLE connection
- stub reconnection path in device_disconnect test
- mock connection setup in init tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 77%


------
https://chatgpt.com/codex/tasks/task_e_68acfd14ba0c83309193a51e80333f3f