### PR TITLE
test: add discovery and device helper coverage

### DIFF
--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from bleak.backends.device import BLEDevice
+
+from custom_components.ld2410.api.devices.device import (
+    BaseDevice,
+    OperationError,
+    _handle_timeout,
+    _merge_data,
+    _parse_response,
+    _unwrap_frame,
+    update_after_operation,
+)
+from custom_components.ld2410.api.const import CMD_BT_GET_PERMISSION
+from custom_components.ld2410.api.models import Advertisement
+
+
+class _Dummy:
+    """Simple class to exercise update_after_operation."""
+
+    def __init__(self) -> None:
+        self.updated = False
+
+    async def update(self) -> None:  # pragma: no cover - exercised via wrapper
+        self.updated = True
+
+    @update_after_operation
+    async def do(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_update_after_operation_calls_update() -> None:
+    """Wrapper ensures update() is called after operation."""
+    dummy = _Dummy()
+    await dummy.do()
+    assert dummy.updated
+
+
+def test_merge_data_recurses() -> None:
+    """Nested dictionaries are merged recursively."""
+    original = {"a": {"b": 1}}
+    new = {"a": {"c": 2}, "d": None}
+    assert _merge_data(original, new) == {"a": {"b": 1, "c": 2}, "d": None}
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_sets_exception() -> None:
+    """Timeout handler sets TimeoutError on unfinished future."""
+    fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+    _handle_timeout(fut)
+    with pytest.raises(asyncio.TimeoutError):
+        await fut
+
+
+def test_unwrap_frame_returns_input_if_no_markers() -> None:
+    """_unwrap_frame returns data when header/footer missing."""
+    data = bytes.fromhex("00112233")
+    assert _unwrap_frame(data, "fdfc", "0403") == data
+
+
+def test_parse_response_unexpected_ack() -> None:
+    """Unexpected ACK raises OperationError."""
+    raw = bytes.fromhex("fdfcfbfa0400a802000004030201")
+    with pytest.raises(OperationError):
+        _parse_response(CMD_BT_GET_PERMISSION, raw)
+
+
+@pytest.mark.asyncio
+async def test_advertisement_changed_detects_changes() -> None:
+    """advertisement_changed returns True when advertisement differs."""
+    dev = BaseDevice(device=BLEDevice(address="AA:BB", name="d", details=None))
+    adv1 = Advertisement("AA:BB", {"k": 1}, dev._device, -40)
+    assert dev.advertisement_changed(adv1)
+    dev._sb_adv_data = adv1
+    adv2 = Advertisement("AA:BB", {"k": 2}, dev._device, -40)
+    assert dev.advertisement_changed(adv2)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,104 @@
+"""Tests for device discovery helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+from custom_components.ld2410.api.discovery import GetDevices
+from custom_components.ld2410.api.models import Advertisement
+
+
+@pytest.mark.asyncio
+async def test_detection_callback_stores_discovery() -> None:
+    """Detection callback stores parsed advertisement data."""
+    gd = GetDevices()
+    device = BLEDevice(address="AA:BB", name="test", details=None)
+    adv_data = AdvertisementData(
+        local_name="test",
+        manufacturer_data={},
+        service_data={},
+        service_uuids=[],
+        tx_power=None,
+        rssi=-60,
+        platform_data=(),
+    )
+    advert = Advertisement("AA:BB", {"model": "ld2410"}, device, -60)
+    with patch(
+        "custom_components.ld2410.api.discovery.parse_advertisement_data",
+        return_value=advert,
+    ):
+        gd.detection_callback(device, adv_data)
+    assert gd._adv_data == {"AA:BB": advert}
+
+
+@pytest.mark.asyncio
+async def test_discover_uses_bleak_scanner() -> None:
+    """Discover calls start and stop on the bleak scanner."""
+    gd = GetDevices()
+    advert = Advertisement(
+        "AA:BB",
+        {"model": "ld2410"},
+        BLEDevice(address="AA:BB", name="dev", details=None),
+        -40,
+    )
+    gd._adv_data = {advert.address: advert}
+
+    scanner = AsyncMock()
+    with (
+        patch(
+            "custom_components.ld2410.api.discovery.bleak.BleakScanner",
+            return_value=scanner,
+        ),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await gd.discover(scan_timeout=0)
+
+    assert result == {advert.address: advert}
+    assert scanner.start.call_count == 1
+    assert scanner.stop.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_devices_by_model_triggers_discover() -> None:
+    """_get_devices_by_model calls discover when cache empty."""
+    gd = GetDevices()
+    advert = Advertisement(
+        "AA:BB",
+        {"model": "ld2410"},
+        BLEDevice(address="AA:BB", name="dev", details=None),
+        -40,
+    )
+
+    async def fake_discover(*args, **kwargs):
+        gd._adv_data = {advert.address: advert}
+        return gd._adv_data
+
+    with patch.object(gd, "discover", side_effect=fake_discover) as mock_disc:
+        result = await gd._get_devices_by_model("ld2410")
+    assert result == {advert.address: advert}
+    mock_disc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_device_data_triggers_discover() -> None:
+    """get_device_data calls discover when cache empty."""
+    gd = GetDevices()
+    advert = Advertisement(
+        "AA:BB",
+        {"address": "AA:BB"},
+        BLEDevice(address="AA:BB", name="dev", details=None),
+        -40,
+    )
+
+    async def fake_discover(*args, **kwargs):
+        gd._adv_data = {advert.address: advert}
+        return gd._adv_data
+
+    with patch.object(gd, "discover", side_effect=fake_discover) as mock_disc:
+        result = await gd.get_device_data("AA:BB")
+    assert result == {advert.address: advert}
+    mock_disc.assert_called_once()


### PR DESCRIPTION
## Summary
- add tests for discovery callbacks and lookups
- cover device helper utilities like update wrappers and frame parsing

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410`

## Coverage
- 80%


------
https://chatgpt.com/codex/tasks/task_e_68ad08580c388330995dd172525a5d96