### PR TITLE
Use constants for intra frame type detection

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -13,6 +13,8 @@ from ..const import (
     CMD_ENABLE_CFG,
     CMD_END_CFG,
     CMD_ENABLE_ENGINEERING,
+    UPLINK_TYPE_BASIC,
+    UPLINK_TYPE_ENGINEERING,
 )
 from .device import Device, OperationError
 
@@ -109,13 +111,13 @@ class LD2410(Device):
             # Not an intra frame
             return None
 
-        frame_type = data[0]
-        if frame_type == 0x01:
+        frame_type = data[:1].hex()
+        if frame_type == UPLINK_TYPE_ENGINEERING:
             ftype = "engineering"
-        elif frame_type == 0x02:
+        elif frame_type == UPLINK_TYPE_BASIC:
             ftype = "basic"
         else:
-            raise ValueError(f"unknown frame type {frame_type:#x}")
+            raise ValueError(f"unknown frame type {frame_type}")
 
         if not data.endswith(b"\x55\x00"):
             raise ValueError("missing frame footer")


### PR DESCRIPTION
## Summary
- decode the intra frame type byte and compare against UPLINK_TYPE_ENGINEERING and UPLINK_TYPE_BASIC

Decoding the frame type byte avoids unnecessary integer conversions and keeps the comparison aligned with the constant definitions for readability and clarity.

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`

Test coverage: 80%


------
https://chatgpt.com/codex/tasks/task_e_68aef2949b80833081d2c7055b0093bd