### PR TITLE
Read parameters after enabling engineering mode

### DIFF
--- a/custom_components/ld2410/api/const/__init__.py
+++ b/custom_components/ld2410/api/const/__init__.py
@@ -13,118 +13,118 @@ CHARACTERISTIC_WRITE = "0000fff2-0000-1000-8000-00805f9b34fb"
 
 # ---------- Frame constants (hex strings) ----------
 TX_HEADER = "FDFCFBFA"  # Downlink (host→radar) command frame header. Command/ACK use same header/footer.
-TX_FOOTER = "04030201"  # Downlink frame footer. ACK frames use this too.  status(2): "0000"=success, "0100"=failure. 
-RX_HEADER = "F4F3F2F1"  # Uplink (radar→host) data frame header. Types: "01"=engineering, "02"=basic. 
+TX_FOOTER = "04030201"  # Downlink frame footer. ACK frames use this too.  status(2): "0000"=success, "0100"=failure.
+RX_HEADER = "F4F3F2F1"  # Uplink (radar→host) data frame header. Types: "01"=engineering, "02"=basic.
 RX_FOOTER = "F8F7F6F5"  # Uplink data frame footer.
 
-# NOTE on ACKs: ACK intra-frame data begins with (sent_cmd | 0x0100) then the return payload.
-# Example: send "FE00" → ACK contains "FE01" then status(2). 
+# NOTE on ACKs: ACK uplink frame data begins with (sent_cmd | 0x0100) then the return payload.
+# Example: send "FE00" → ACK contains "FE01" then status(2).
 
 # ---------- Command words (hex strings, little-endian) ----------
 
 # Enable configuration session (must precede other config commands). Returns status + protocol version + buffer size.
 CMD_ENABLE_CFG = "FF00"  # value: "0001"
-# return: status(2) + proto_ver(2="0001") + buf_size(2="4000"). "0000"=OK, "0100"=fail. 
+# return: status(2) + proto_ver(2="0001") + buf_size(2="4000"). "0000"=OK, "0100"=fail.
 
 # End configuration session (resume normal working mode).
 CMD_END_CFG = "FE00"  # value: (none)
-# return: status(2). Send again CMD_ENABLE_CFG to re-enter config mode. 
+# return: status(2). Send again CMD_ENABLE_CFG to re-enter config mode.
 
 # Set max detection gates (move & still) and "no-one" duration (unoccupied delay).
 CMD_SET_MAX_GATES_AND_NOBODY = "6000"
 # value (all words little-endian, values are u32 LE):
 #   "0000"+<u32 move_gate 2..8>  +  "0100"+<u32 still_gate 2..8>  +  "0200"+<u32 nobody_sec 0..65535>
-# return: status(2). Takes effect immediately; retained across power-cycles. Defaults in Table 7. 
+# return: status(2). Takes effect immediately; retained across power-cycles. Defaults in Table 7.
 
 # Read current configuration (gates, per-gate sensitivities, unoccupied duration).
 CMD_READ_PARAMS = "6100"  # value: (none)
 # return: status(2) + "AA"(1B) + N_max(1B) + cfg_max_move(1B) + cfg_max_still(1B)
-#       + move_sens[0..N](1B each) + still_sens[0..N](1B each) + nobody_duration(2). 
+#       + move_sens[0..N](1B each) + still_sens[0..N](1B each) + nobody_duration(2).
 
 # Enable engineering mode (uplink adds per-gate energy arrays, data type "01").
 CMD_ENABLE_ENGINEERING = "6200"  # value: (none)
-# return: status(2). Setting is volatile (lost on power-off). 
+# return: status(2). Setting is volatile (lost on power-off).
 
 # Disable engineering mode (uplink reverts to basic target info, data type "02").
 CMD_DISABLE_ENGINEERING = "6300"  # value: (none)
-# return: status(2). 
+# return: status(2).
 
 # Set sensitivities for a specific gate or all gates.
 CMD_SET_SENSITIVITY = "6400"
 # value:
 #   "0000"+<u32 gate_id 0..8 or 0x0000FFFF for ALL> + "0100"+<u32 move 0..100> + "0200"+<u32 still 0..100>
-# return: status(2). Use ALL ("FFFF") to apply uniform values to every gate. 
+# return: status(2). Use ALL ("FFFF") to apply uniform values to every gate.
 
 # Read firmware version (type, major, minor/build).
 CMD_READ_FW = "A000"  # value: (none)
-# return: status(2) + fw_type(2="0001") + major(2) + minor(4). Example decodes to Vx.y.yyyymmddhh. 
+# return: status(2) + fw_type(2="0001") + major(2) + minor(4). Example decodes to Vx.y.yyyymmddhh.
 
 # Set UART baud rate (persists; takes effect after reboot).
 CMD_SET_BAUD = "A100"  # value: BAUD_* index(2)
-# return: status(2). Indices: "0001"=9600 … "0008"=460800; factory default "0007"=256000. 
+# return: status(2). Indices: "0001"=9600 … "0008"=460800; factory default "0007"=256000.
 
 # Restore factory defaults (persists; takes effect after reboot).
 CMD_FACTORY_RESET = "A200"  # value: (none)
-# return: status(2). Table 7 lists default gates/sensitivities/baud. 
+# return: status(2). Table 7 lists default gates/sensitivities/baud.
 
 # Reboot module (module restarts after ACK).
 CMD_REBOOT = "A300"  # value: (none)
-# return: status(2). 
+# return: status(2).
 
 # Bluetooth on/off (requires reboot to apply).
 CMD_BT_ONOFF = "A400"  # value: "0001"=ON, "0000"=OFF
-# return: status(2). BT is ON by default. 
+# return: status(2). BT is ON by default.
 
 # Get MAC address (over UART).
 CMD_GET_MAC = "A500"  # value: "0001"
-# return: status(2) + fixed_type(1B="00") + MAC(6B; shown big-endian in example). 
+# return: status(2) + fixed_type(1B="00") + MAC(6B; shown big-endian in example).
 
 # Obtain Bluetooth permission (checks password) — reply is sent via Bluetooth, not UART.
 CMD_BT_GET_PERMISSION = (
     "A800"  # value: 6B password ("4869 4C69 6E6B" for "HiLink" split in LE pairs)
 )
-# return: status(2). Treat "0000"=allowed, "0100"=denied (per generic success/fail). 
+# return: status(2). Treat "0000"=allowed, "0100"=denied (per generic success/fail).
 
 # Set Bluetooth password (stores new 6B password).
 CMD_BT_SET_PWD = "A900"  # value: 6B password (small-end order)
-# return: status(2). 
+# return: status(2).
 
 # Set distance resolution per gate (0.75 m or 0.2 m; persists; needs reboot).
 CMD_SET_RES = "AA00"  # value: RES_* index(2)
-# return: status(2). "0000"→0.75 m; "0001"→0.20 m. Example shows index "0001". 
+# return: status(2). "0000"→0.75 m; "0001"→0.20 m. Example shows index "0001".
 
 # Query distance resolution (returns current index).
 CMD_GET_RES = "AB00"  # value: (none)
-# return: status(2) + RES_* index(2). Example ACK shows "... 0001 00" → 0.2 m per gate. 
+# return: status(2) + RES_* index(2). Example ACK shows "... 0001 00" → 0.2 m per gate.
 
 # Set auxiliary control (ambient light sensor & output config).
 CMD_SET_AUX = "AD00"  # value: 4B config = [mode(1B) + threshold(1B) + out_level(1B) + reserved(1B)]
 # return: status(2). Modes: 0x00=disable light sensor control (OUT always triggered by presence),
 #        0x01=enable (OUT active only if ambient light < threshold), 0x02=enable (OUT active only if ambient light > threshold).
-#        Out_level: 0x00=OUT default low (active high on detect), 0x01=OUT default high (active low on detect). 
+#        Out_level: 0x00=OUT default low (active high on detect), 0x01=OUT default high (active low on detect).
 
 # Read auxiliary control configuration.
 CMD_GET_AUX = "AE00"  # value: (none)
-# return: status(2) + 4B config (same format as CMD_SET_AUX). 
+# return: status(2) + 4B config (same format as CMD_SET_AUX).
 
 # Start automatic threshold detection (background noise calibration).
 CMD_START_AUTO_THRESH = "0B00"  # value: <u16 duration_sec> (detection time in seconds)
-# return: status(2). Sensor performs background noise detection for the given duration, then auto-adjusts sensitivities. 
+# return: status(2). Sensor performs background noise detection for the given duration, then auto-adjusts sensitivities.
 
 # Query status of automatic threshold detection.
 CMD_QUERY_AUTO_THRESH = "1B00"  # value: (none)
-# return: status(2) + status_code(2). 0x0000 = not in progress, 0x0001 = in progress, 0x0002 = completed (calibration done). 
+# return: status(2) + status_code(2). 0x0000 = not in progress, 0x0001 = in progress, 0x0002 = completed (calibration done).
 
 # ---------- Parameter words (for 0x0060 “max gates & nobody”) ----------
 PAR_MAX_MOVE_GATE = "0000"  # u32 move gate: 2..8
 PAR_MAX_STILL_GATE = "0100"  # u32 still gate: 2..8
-PAR_NOBODY_DURATION = "0200"  # u32 seconds: 0..65535  (aka "no-one duration"). 
+PAR_NOBODY_DURATION = "0200"  # u32 seconds: 0..65535  (aka "no-one duration").
 
 # ---------- Parameter words (for 0x0064 “set sensitivity”) ----------
 PAR_DISTANCE_GATE = "0000"  # u32 gate: 0..8, or ALL_GATES
 PAR_MOVE_SENS = "0100"  # u32 sensitivity: 0..100
 PAR_STILL_SENS = "0200"  # u32 sensitivity: 0..100
-ALL_GATES = "FFFF"  # special selector meaning "apply to all gates". 
+ALL_GATES = "FFFF"  # special selector meaning "apply to all gates".
 
 # ---------- Baud rate indices (for CMD_SET_BAUD A100) ----------
 BAUD_9600 = "0001"
@@ -134,28 +134,41 @@ BAUD_57600 = "0004"
 BAUD_115200 = "0005"
 BAUD_230400 = "0006"
 BAUD_256000 = "0007"  # factory default
-BAUD_460800 = "0008"  # per Table 6. 
+BAUD_460800 = "0008"  # per Table 6.
 
 # ---------- Distance resolution indices (for CMD_SET_RES / CMD_GET_RES) ----------
 RES_PER_GATE_0_75M = "0000"  # each distance gate = 0.75 m
-RES_PER_GATE_0_2M = "0001"  # each distance gate = 0.20 m  (query example returns "0001"). 
+RES_PER_GATE_0_2M = (
+    "0001"  # each distance gate = 0.20 m  (query example returns "0001").
+)
 
 # ---------- Auxiliary control function values (for CMD_SET_AUX / CMD_GET_AUX) ----------
-LIGHT_CONTROL_OFF = "00"    # 0x00 = Disable light-sensing control (ambient light ignored)
-LIGHT_CONTROL_ENABLE_UNDER = "01"  # 0x01 = Enable aux control (OUT active if ambient < threshold)
-LIGHT_CONTROL_ENABLE_OVER = "02"   # 0x02 = Enable aux control (OUT active if ambient > threshold)
-LIGHT_THRESHOLD_DEFAULT = "80"     # Default light threshold = 0x80 (128)
-OUT_LEVEL_LOW = "00"    # 0x00 = OUT default low (outputs low when idle, high when target detected)
-OUT_LEVEL_HIGH = "01"   # 0x01 = OUT default high (outputs high when idle, low when target detected)
+LIGHT_CONTROL_OFF = "00"  # 0x00 = Disable light-sensing control (ambient light ignored)
+LIGHT_CONTROL_ENABLE_UNDER = (
+    "01"  # 0x01 = Enable aux control (OUT active if ambient < threshold)
+)
+LIGHT_CONTROL_ENABLE_OVER = (
+    "02"  # 0x02 = Enable aux control (OUT active if ambient > threshold)
+)
+LIGHT_THRESHOLD_DEFAULT = "80"  # Default light threshold = 0x80 (128)
+OUT_LEVEL_LOW = (
+    "00"  # 0x00 = OUT default low (outputs low when idle, high when target detected)
+)
+OUT_LEVEL_HIGH = (
+    "01"  # 0x01 = OUT default high (outputs high when idle, low when target detected)
+)
 
 # ---------- Uplink data types (for RX payload interpretation) ----------
 UPLINK_TYPE_ENGINEERING = "01"  # per-gate energies appended to basic target info
-UPLINK_TYPE_BASIC = "02"  # basic target info only (default). 
+UPLINK_TYPE_BASIC = "02"  # basic target info only (default).
+
 
 class Model(StrEnum):
     """Device models."""
+
     LD2410 = "HLK-LD2410"
     # Additional models (e.g., LD2410B, LD2410C) can be represented by the same commands
+
 
 __all__ = [
     # exports

--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -127,8 +127,8 @@ def _unwrap_response(data: bytes) -> bytes:
     return _unwrap_frame(data, TX_HEADER, TX_FOOTER)
 
 
-def _unwrap_intra_frame(data: bytes) -> bytes:
-    """Remove header and footer from an intra frame."""
+def _unwrap_uplink_frame(data: bytes) -> bytes:
+    """Remove header and footer from an uplink frame."""
     return _unwrap_frame(data, RX_HEADER, RX_FOOTER)
 
 
@@ -492,8 +492,8 @@ class BaseDevice:
             await self._execute_forced_disconnect()
             raise
 
-    def parse_intra_frame(self, data: bytes) -> dict[str, Any] | None:
-        """Parse an uplink intra frame.
+    def _parse_uplink_frame(self, data: bytes) -> dict[str, Any] | None:
+        """Parse an uplink frame.
 
         Subclasses should override this to handle device specific frames.
         """
@@ -513,14 +513,14 @@ class BaseDevice:
                     data.hex(),
                 )
             return
-        # Notification is an intra frame from the device
+        # Notification is an uplink frame from the device
         elif data.startswith(bytearray.fromhex(RX_HEADER)):
-            payload = _unwrap_intra_frame(data)
+            payload = _unwrap_uplink_frame(data)
             try:
-                #_LOGGER.debug("%s: Received intra frame: %s", self.name, payload.hex())
-                parsed = self.parse_intra_frame(payload)
+                # _LOGGER.debug("%s: Received uplink frame: %s", self.name, payload.hex())
+                parsed = self._parse_uplink_frame(payload)
             except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.error("%s: Failed to parse intra frame: %s", self.name, err)
+                _LOGGER.error("%s: Failed to parse uplink frame: %s", self.name, err)
             else:
                 if parsed and self._update_parsed_data(parsed):
                     self._last_full_update = time.monotonic()

--- a/custom_components/ld2410/binary_sensor.py
+++ b/custom_components/ld2410/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
 
 try:
     from homeassistant.helpers.entity_platform import (
@@ -41,6 +42,12 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
         name="Occupancy",
         device_class=BinarySensorDeviceClass.OCCUPANCY,
         entity_registry_enabled_default=True,
+    ),
+    "out_pin": BinarySensorEntityDescription(
+        key="out_pin",
+        name="OUT pin",
+        entity_registry_enabled_default=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }
 

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -113,6 +113,13 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "photo_sensor": SensorEntityDescription(
+        key="photo_sensor",
+        name="Photo sensor",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -29,8 +29,8 @@ except ImportError:  # pragma: no cover - testing fallback
 
 
 @pytest.mark.asyncio
-async def test_entities_stay_available_with_intra_frames(hass: HomeAssistant) -> None:
-    """Entities stay available when intra frames are received without advertisements."""
+async def test_entities_stay_available_with_uplink_frames(hass: HomeAssistant) -> None:
+    """Entities stay available when uplink frames are received without advertisements."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
 

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from bleak.backends.device import BLEDevice
@@ -19,6 +19,14 @@ async def test_reconnect_after_unexpected_disconnect():
     device.cmd_enable_config = AsyncMock()
     device.cmd_enable_engineering_mode = AsyncMock()
     device.cmd_end_config = AsyncMock()
+    device.cmd_read_params = AsyncMock(
+        return_value={
+            "move_gate_sensitivity": [],
+            "still_gate_sensitivity": [],
+            "nobody_duration": 0,
+        }
+    )
+    device._update_parsed_data = MagicMock()
 
     device._disconnected(None)
     await asyncio.sleep(0)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -149,6 +149,20 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_end_config",
             AsyncMock(),
         ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_read_params",
+            AsyncMock(
+                return_value={
+                    "move_gate_sensitivity": [],
+                    "still_gate_sensitivity": [],
+                    "nobody_duration": 0,
+                }
+            ),
+        ),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",
+            autospec=True,
+        ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -193,6 +207,20 @@ async def test_unload_disconnects_device(hass: HomeAssistant) -> None:
         patch(
             "custom_components.ld2410.api.LD2410.cmd_end_config",
             AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_read_params",
+            AsyncMock(
+                return_value={
+                    "move_gate_sensitivity": [],
+                    "still_gate_sensitivity": [],
+                    "nobody_duration": 0,
+                }
+            ),
+        ),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",
+            autospec=True,
         ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_uplink_parser.py
+++ b/tests/test_uplink_parser.py
@@ -1,4 +1,4 @@
-"""Tests for intra frame parser and notification handling."""
+"""Tests for uplink frame parser and notification handling."""
 
 from __future__ import annotations
 
@@ -13,13 +13,13 @@ from custom_components.ld2410.api.const import RX_HEADER, RX_FOOTER
 from custom_components.ld2410.api.models import Advertisement
 
 
-def test_parse_intra_frame_basic() -> None:
-    """Ensure basic intra frames are parsed correctly."""
+def test_parse_uplink_frame_basic() -> None:
+    """Ensure basic uplink frames are parsed correctly."""
     payload = bytes.fromhex("02aa0101001402002803005500")
     device = LD2410(
         device=BLEDevice(address="AA:BB", name="test", details=None, rssi=-60)
     )
-    result = device.parse_intra_frame(payload)
+    result = device._parse_uplink_frame(payload)
     assert result == {
         "type": "basic",
         "moving": True,
@@ -35,7 +35,7 @@ def test_parse_intra_frame_basic() -> None:
 
 @pytest.mark.asyncio
 async def test_notification_handler_engineering_frame_updates_data(caplog) -> None:
-    """Ensure engineering intra frames update device data and cache."""
+    """Ensure engineering uplink frames update device data and cache."""
     payload_hex = (
         "01aa034e00334e00643e000808123318050403050306000064202627190f1501015500"
     )
@@ -78,6 +78,8 @@ async def test_notification_handler_engineering_frame_updates_data(caplog) -> No
         "max_still_gate": 8,
         "move_gate_energy": [18, 51, 24, 5, 4, 3, 5, 3, 6],
         "still_gate_energy": [0, 0, 100, 32, 38, 39, 25, 15, 21],
+        "photo_sensor": 1,
+        "out_pin": True,
     }
     assert device.parsed_data == expected
     assert called
@@ -115,6 +117,8 @@ async def test_notification_handler_initializes_without_advertisement() -> None:
         "max_still_gate": 8,
         "move_gate_energy": [18, 51, 24, 5, 4, 3, 5, 3, 6],
         "still_gate_energy": [0, 0, 100, 32, 38, 39, 25, 15, 21],
+        "photo_sensor": 1,
+        "out_pin": True,
     }
 
     assert device.parsed_data == expected


### PR DESCRIPTION
## Summary
- retrieve device parameters after entering engineering mode and merge sensitivities and nobody duration into stored data
- wrap engineering-mode command in configuration session instead of toggling config in caller
- rename intra-frame parser to `_parse_uplink_frame` and update all references to use "uplink frame"
- parse photo sensor and OUT pin status from engineering uplink frames
- add Home Assistant entities for OUT pin (binary) and photo sensor readings
- add unit tests for parameter retrieval, uplink frame parsing, and sensor exposure

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov` (81% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68af10d811bc8330851e3f03af4c6b65