### PR TITLE
Add per-gate sensitivity sliders

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -33,6 +33,7 @@ PLATFORMS_BY_TYPE = {
         Platform.BINARY_SENSOR,
         Platform.SENSOR,
         Platform.BUTTON,
+        Platform.NUMBER,
     ],
 }
 CLASS_BY_DEVICE = {SupportedModels.LD2410.value: api.LD2410}

--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -16,6 +16,10 @@ from ..const import (
     CMD_READ_PARAMS,
     CMD_START_AUTO_THRESH,
     CMD_QUERY_AUTO_THRESH,
+    CMD_SET_SENSITIVITY,
+    PAR_DISTANCE_GATE,
+    PAR_MOVE_SENS,
+    PAR_STILL_SENS,
     UPLINK_TYPE_BASIC,
     UPLINK_TYPE_ENGINEERING,
 )
@@ -132,6 +136,42 @@ class LD2410(Device):
         if not response or len(response) < 4 or response[:2] != b"\x00\x00":
             raise OperationError("Failed to query automatic threshold status")
         return int.from_bytes(response[2:4], "little")
+
+    async def cmd_set_gate_sensitivity(self, gate: int, move: int, still: int) -> None:
+        """Set move and still sensitivity for a gate."""
+        if not 0 <= gate <= 8:
+            raise ValueError("gate must be 0..8")
+        if not 0 <= move <= 100:
+            raise ValueError("move must be 0..100")
+        if not 0 <= still <= 100:
+            raise ValueError("still must be 0..100")
+        await self.cmd_enable_config()
+        try:
+            payload = (
+                PAR_DISTANCE_GATE
+                + gate.to_bytes(2, "little").hex()
+                + PAR_MOVE_SENS
+                + move.to_bytes(2, "little").hex()
+                + PAR_STILL_SENS
+                + still.to_bytes(2, "little").hex()
+            )
+            response = await self._send_command(CMD_SET_SENSITIVITY + payload)
+            if response != b"\x00\x00":
+                raise OperationError("Failed to set sensitivity")
+            move_list = list(self.parsed_data.get("move_gate_sensitivity") or [])
+            still_list = list(self.parsed_data.get("still_gate_sensitivity") or [])
+            if gate < len(move_list):
+                move_list[gate] = move
+            if gate < len(still_list):
+                still_list[gate] = still
+            self._update_parsed_data(
+                {
+                    "move_gate_sensitivity": move_list,
+                    "still_gate_sensitivity": still_list,
+                }
+            )
+        finally:
+            await self.cmd_end_config()
 
     async def cmd_read_params(self) -> Dict[str, Any]:
         """Read and parse device configuration parameters."""

--- a/custom_components/ld2410/number.py
+++ b/custom_components/ld2410/number.py
@@ -1,0 +1,74 @@
+"""Number entities for gate sensitivities."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.core import HomeAssistant
+
+try:
+    from homeassistant.helpers.entity_platform import (
+        AddConfigEntryEntitiesCallback,
+    )
+except ImportError:  # Home Assistant <2024.6
+    from homeassistant.helpers.entity_platform import (
+        AddEntitiesCallback as AddConfigEntryEntitiesCallback,
+    )
+
+from .coordinator import ConfigEntryType, DataCoordinator
+from .entity import Entity, exception_handler
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntryType,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up number entities from config entry."""
+    coordinator = entry.runtime_data
+    entities: list[NumberEntity] = []
+    for gate in range(9):
+        entities.append(
+            GateSensitivityNumber(coordinator, "move_gate_sensitivity", gate)
+        )
+        entities.append(
+            GateSensitivityNumber(coordinator, "still_gate_sensitivity", gate)
+        )
+    async_add_entities(entities)
+
+
+class GateSensitivityNumber(Entity, NumberEntity):
+    """Representation of a gate sensitivity slider."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, coordinator: DataCoordinator, data_key: str, gate: int) -> None:
+        super().__init__(coordinator)
+        self._data_key = data_key
+        self._gate = gate
+        prefix = "Motion" if data_key == "move_gate_sensitivity" else "Static"
+        self._attr_name = f"{prefix} gate {gate} sensitivity"
+        self._attr_unique_id = f"{coordinator.base_unique_id}-{data_key}-{gate}"
+
+    @property
+    def native_value(self) -> int | None:
+        values = self.parsed_data.get(self._data_key)
+        if values is None or len(values) <= self._gate:
+            return None
+        return values[self._gate]
+
+    @exception_handler
+    async def async_set_native_value(self, value: float) -> None:
+        move_values = self.parsed_data.get("move_gate_sensitivity") or []
+        still_values = self.parsed_data.get("still_gate_sensitivity") or []
+        move = move_values[self._gate] if self._gate < len(move_values) else 0
+        still = still_values[self._gate] if self._gate < len(still_values) else 0
+        if self._data_key == "move_gate_sensitivity":
+            move = int(value)
+        else:
+            still = int(value)
+        await self._device.cmd_set_gate_sensitivity(self._gate, move, still)

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -118,9 +118,10 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         name="Photo sensor",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ILLUMINANCE,
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
 }
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,90 @@
+"""Test gate sensitivity numbers."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from custom_components.ld2410.const import DOMAIN
+
+from . import LD2410b_SERVICE_INFO
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:  # Home Assistant <2023.9
+    from .mocks import MockConfigEntry
+
+try:
+    from tests.components.bluetooth import inject_bluetooth_service_info
+except ImportError:  # Home Assistant <2023.9
+    from .mocks import inject_bluetooth_service_info
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
+    """Test sliders for gate sensitivity."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    mock_parsed = {
+        "firmware_version": "2.44.24073110",
+        "firmware_build_date": datetime(2024, 7, 31, 10, 0, tzinfo=timezone.utc),
+        "move_gate_sensitivity": list(range(10, 19)),
+        "still_gate_sensitivity": list(range(20, 29)),
+    }
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.connect_and_subscribe",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value=mock_parsed),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_gate_sensitivity",
+            AsyncMock(),
+        ) as set_mock,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        for gate in range(9):
+            move_id = f"number.test_name_motion_gate_{gate}_sensitivity"
+            still_id = f"number.test_name_static_gate_{gate}_sensitivity"
+            assert hass.states.get(move_id).state == str(10 + gate)
+            assert hass.states.get(still_id).state == str(20 + gate)
+
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {
+                "entity_id": "number.test_name_motion_gate_0_sensitivity",
+                "value": 55,
+            },
+            blocking=True,
+        )
+
+        set_mock.assert_awaited_once_with(0, 55, 20)


### PR DESCRIPTION
## Summary
- support setting gate sensitivities in LD2410 device API
- expose motion and static gate sensitivity sliders
- enable photo sensor by default

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410`


------
https://chatgpt.com/codex/tasks/task_e_68af4451024c83309a39f9cefaa9f8cf