### PR TITLE
Rename moving gate to motion gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For best results, use an [ESPHome Bluetooth Proxy](https://esphome.io/components
 ### Numeric sensors
 - **Detect distance** – distance at which a target is detected (cm).
 - **Photo Sensor** – photo sensor value (0-255).
-- **Moving Gates** – Energy level of individual motion gates (0-100%)
+- **Motion Gates** – Energy level of individual motion gates (0-100%)
 - **Static Gates** – Energy level of individual static gates (0-100%)
 
 ### Diagnostic sensors
@@ -31,7 +31,7 @@ For best results, use an [ESPHome Bluetooth Proxy](https://esphome.io/components
 - **Still distance** – distance to the closest stationary target (cm).
 - **Moving energy** – strongest gate energy of moving target.
 - **Still energy** – strongest gate energy of stationary targets.
-- **Max moving gate** – index of latest moving gate.
+- **Max motion gate** – index of latest motion gate.
 - **Max still gate** – index of latest still gate.
 - **Firmware version** – device firmware version.
 - **Firmware build date** – build date of the installed firmware.

--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -100,7 +100,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "max_move_gate": SensorEntityDescription(
         key="max_move_gate",
-        name="Max moving gate",
+        name="Max motion gate",
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -172,7 +172,7 @@ class GateEnergySensor(Entity, SensorEntity):
         super().__init__(coordinator)
         self._data_key = data_key
         self._gate = gate
-        prefix = "Moving" if data_key == "move_gate_energy" else "Still"
+        prefix = "Motion" if data_key == "move_gate_energy" else "Still"
         self.entity_description = SensorEntityDescription(
             key=f"{data_key}_{gate}",
             name=f"{prefix} gate {gate} energy",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -208,7 +208,7 @@ async def test_entities_created_without_initial_data(hass: HomeAssistant) -> Non
     assert registry.async_get("sensor.test_name_firmware_version") is not None
     for gate in range(9):
         assert (
-            registry.async_get(f"sensor.test_name_moving_gate_{gate}_energy")
+            registry.async_get(f"sensor.test_name_motion_gate_{gate}_energy")
             is not None
         )
         assert (


### PR DESCRIPTION
## Summary
- rename "Moving gate" terminology to "Motion gate" in user-facing labels
- update docs and tests for new motion gate sensor identifiers

## Reasoning
- Aligns entity naming with "motion" terminology for clarity

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410 --cov-report=term` (82% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68af74c9ef108330924e6db3cd32e05c