### PR TITLE
Cancel operations on unexpected disconnect

### DIFF
--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -205,6 +205,8 @@ class BaseDevice:
         for attempt in range(max_attempts):
             try:
                 return await self._send_command_locked(key, command)
+            except asyncio.CancelledError:
+                raise
             except BleakNotFoundError:
                 _LOGGER.error(
                     "%s: device not found, no longer in range, or poor RSSI: %s",
@@ -412,7 +414,7 @@ class BaseDevice:
         if self._operation_task and not self._operation_task.done():
             self._operation_task.cancel()
         if self._notify_future and not self._notify_future.done():
-            self._notify_future.set_exception(asyncio.TimeoutError)
+            self._notify_future.cancel()
 
     def _disconnect_from_timer(self):
         """Disconnect from device."""

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -90,7 +90,11 @@ async def test_disconnected_cancels_operation() -> None:
         await asyncio.sleep(100)
 
     with (
-        patch.object(device, "_send_command_locked_with_retry", new=long_running),
+        patch(
+            "custom_components.ld2410.api.devices.device.BLEAK_RETRY_EXCEPTIONS",
+            (asyncio.CancelledError,),
+        ),
+        patch.object(device, "_send_command_locked", new=long_running),
         patch.object(device, "_restart_connection", AsyncMock()),
     ):
         task = asyncio.create_task(device._send_command("0000"))


### PR DESCRIPTION
## Summary
- cancel in-progress command when device disconnects unexpectedly
- test operation cancellation to prevent lock from lingering

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 83%


------
https://chatgpt.com/codex/tasks/task_e_68af7b8f1cd483309203aaaaaa31d4ba