### PR TITLE
Ensure engineering mode before reading params

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -51,9 +51,8 @@ class LD2410(Device):
             self.loop.create_task(self._restart_connection())
 
     async def connect_and_update(self):
-        """Begin connection, sends password and enables engineering mode."""
+        """Ensure connection and refresh configuration parameters."""
         await self._ensure_connected()
-        await self.cmd_enable_engineering_mode()
         params = await self.cmd_read_params()
         self._update_parsed_data(
             {

--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -53,6 +53,7 @@ class LD2410(Device):
     async def connect_and_update(self):
         """Begin connection, sends password and enables engineering mode."""
         await self._ensure_connected()
+        await self.cmd_enable_engineering_mode()
         params = await self.cmd_read_params()
         self._update_parsed_data(
             {

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -136,10 +136,7 @@ async def test_enable_engineering_fail() -> None:
     )
     with pytest.raises(OperationError):
         await dev.cmd_enable_engineering_mode()
-    assert dev.keys == [
-        CMD_ENABLE_CFG + "0001",
-        CMD_ENABLE_ENGINEERING
-    ]
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_ENABLE_ENGINEERING]
 
 
 @pytest.mark.asyncio
@@ -174,10 +171,7 @@ async def test_auto_thresholds_fail() -> None:
     )
     with pytest.raises(OperationError):
         await dev.cmd_auto_thresholds(5)
-    assert dev.keys == [
-        CMD_ENABLE_CFG + "0001",
-        CMD_START_AUTO_THRESH + "0500"
-    ]
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_START_AUTO_THRESH + "0500"]
 
 
 @pytest.mark.asyncio
@@ -213,10 +207,7 @@ async def test_query_auto_thresholds_fail() -> None:
     )
     with pytest.raises(OperationError):
         await dev.cmd_query_auto_thresholds()
-    assert dev.keys == [
-        CMD_ENABLE_CFG + "0001",
-        CMD_QUERY_AUTO_THRESH
-    ]
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_QUERY_AUTO_THRESH]
 
 
 @pytest.mark.asyncio
@@ -267,7 +258,7 @@ async def test_set_gate_sensitivity_fail() -> None:
         await dev.cmd_set_gate_sensitivity(4, 15, 40)
     assert dev.keys == [
         CMD_ENABLE_CFG + "0001",
-        CMD_SET_SENSITIVITY + "00000400000001000f000000020028000000"
+        CMD_SET_SENSITIVITY + "00000400000001000f000000020028000000",
     ]
 
 
@@ -326,7 +317,7 @@ async def test_connect_and_update_reads_params() -> None:
         b"\x00\x00",
     ]
     dev = _TestDevice(password=None, response=resp)
-    dev._ensure_connected = AsyncMock()
+    dev._ensure_connected = AsyncMock(side_effect=dev.cmd_enable_engineering_mode)
     await dev.connect_and_update()
     assert dev.keys == [
         CMD_ENABLE_CFG + "0001",

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -108,13 +108,15 @@ async def test_disconnect_clears_command_queue() -> None:
         password="HiLink",
     )
     await device._operation_lock.acquire()
-    task = asyncio.create_task(device._send_command("FF000100"))
+    task1 = asyncio.create_task(device._send_command("FF000100"))
+    task2 = asyncio.create_task(device._send_command("FF000100"))
     await asyncio.sleep(0)
     device._client = AsyncMock()
     device._client.disconnect = AsyncMock()
     async with device._connect_lock:
         await device._execute_disconnect_with_lock()
     await asyncio.sleep(0)
-    with pytest.raises(OperationError):
-        await task
+    for task in (task1, task2):
+        with pytest.raises(OperationError):
+            await task
     assert not device._operation_lock.locked()


### PR DESCRIPTION
## Summary
- ensure LD2410 enables engineering mode before reading parameters
- verify multiple queued commands are aborted on disconnect

## Testing
- `ruff check . --fix`
- `ruff format custom_components/ld2410/api/devices/ld2410.py tests/test_device_disconnect.py`
- `pytest`
- `pytest --cov`

## Coverage
- 83%


------
https://chatgpt.com/codex/tasks/task_e_68af9bcf81a88330b0f29f961a1abf70