### PR TITLE
Add baud rate select entity

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -34,6 +34,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SENSOR,
         Platform.BUTTON,
         Platform.NUMBER,
+        Platform.SELECT,
     ],
 }
 CLASS_BY_DEVICE = {SupportedModels.LD2410.value: api.LD2410}

--- a/custom_components/ld2410/select.py
+++ b/custom_components/ld2410/select.py
@@ -1,0 +1,63 @@
+"""Select entities for baud rate configuration."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+try:
+    from homeassistant.helpers.entity_platform import (
+        AddConfigEntryEntitiesCallback,
+    )
+except ImportError:  # Home Assistant <2024.6
+    from homeassistant.helpers.entity_platform import (
+        AddEntitiesCallback as AddConfigEntryEntitiesCallback,
+    )
+
+from .coordinator import ConfigEntryType, DataCoordinator
+from .entity import Entity, exception_handler
+
+PARALLEL_UPDATES = 0
+
+BAUD_OPTIONS = [
+    "9600",
+    "19200",
+    "38400",
+    "57600",
+    "115200",
+    "230400",
+    "256000",
+    "460800",
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntryType,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up select entities for a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities([BaudRateSelect(coordinator)])
+
+
+class BaudRateSelect(Entity, SelectEntity):
+    """Representation of the baud rate configuration select."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_name = "Baud rate"
+    _attr_options = BAUD_OPTIONS
+
+    def __init__(self, coordinator: DataCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}-baud_rate"
+
+    @property
+    def current_option(self) -> str | None:
+        value = self.parsed_data.get("baud_rate")
+        return str(value) if value is not None else None
+
+    @exception_handler
+    async def async_select_option(self, option: str) -> None:
+        await self._device.cmd_set_baud_rate(int(option))

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -16,11 +16,13 @@ from custom_components.ld2410.api.const import (
     CMD_ENABLE_CFG,
     CMD_END_CFG,
     CMD_ENABLE_ENGINEERING,
+    CMD_SET_BAUD,
     CMD_START_AUTO_THRESH,
     CMD_QUERY_AUTO_THRESH,
     CMD_SET_MAX_GATES_AND_NOBODY,
     CMD_SET_SENSITIVITY,
     CMD_READ_PARAMS,
+    BAUD_115200,
     PAR_MAX_MOVE_GATE,
     PAR_MAX_STILL_GATE,
     PAR_NOBODY_DURATION,
@@ -384,6 +386,45 @@ async def test_set_absence_delay_fail() -> None:
         + "1e000000"
     )
     assert dev.keys == [CMD_ENABLE_CFG + "0001", expected_payload]
+
+
+@pytest.mark.asyncio
+async def test_set_baud_rate_success() -> None:
+    """Set baud rate command sends correct key."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x00\x00",
+            b"\x00\x00",
+        ],
+    )
+    await dev.cmd_set_baud_rate(115200)
+    assert dev.keys == [
+        CMD_ENABLE_CFG + "0001",
+        CMD_SET_BAUD + BAUD_115200,
+        CMD_END_CFG,
+    ]
+    assert dev.parsed_data["baud_rate"] == 115200
+
+
+@pytest.mark.asyncio
+async def test_set_baud_rate_fail() -> None:
+    """Set baud rate command raises on failure."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x01\x00",
+            b"\x00\x00",
+        ],
+    )
+    with pytest.raises(OperationError):
+        await dev.cmd_set_baud_rate(115200)
+    assert dev.keys == [
+        CMD_ENABLE_CFG + "0001",
+        CMD_SET_BAUD + BAUD_115200,
+    ]
 
 
 def test_unwrap_response():

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,30 @@
+"""Test baud rate select."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.ld2410.select import BaudRateSelect
+
+
+class FakeCoordinator:
+    def __init__(self, device):
+        self.device = device
+        self.base_unique_id = "uid"
+        self.device_name = "name"
+        self.model = "ld2410"
+        self.ble_device = SimpleNamespace(address="AA:BB")
+
+
+@pytest.mark.asyncio
+async def test_baud_rate_select_sets_option():
+    device = SimpleNamespace(
+        cmd_set_baud_rate=AsyncMock(), parsed_data={"baud_rate": 256000}
+    )
+    coordinator = FakeCoordinator(device)
+    select = BaudRateSelect(coordinator)
+    assert select.current_option == "256000"
+    assert "115200" in select.options
+    await select.async_select_option("115200")
+    device.cmd_set_baud_rate.assert_awaited_once_with(115200)


### PR DESCRIPTION
## Summary
- add baud rate select entity and register select platform
- implement UART baud rate command
- cover new features with tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- `84%`


------
https://chatgpt.com/codex/tasks/task_e_68b0912b4e5483308327396eb40fcf24