### PR TITLE
Add resolution configuration support for LD2410

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -34,6 +34,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SENSOR,
         Platform.BUTTON,
         Platform.NUMBER,
+        Platform.SELECT,
     ],
 }
 CLASS_BY_DEVICE = {SupportedModels.LD2410.value: api.LD2410}

--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -18,6 +18,8 @@ from ..const import (
     CMD_QUERY_AUTO_THRESH,
     CMD_SET_MAX_GATES_AND_NOBODY,
     CMD_SET_SENSITIVITY,
+    CMD_SET_RES,
+    CMD_GET_RES,
     PAR_DISTANCE_GATE,
     PAR_MOVE_SENS,
     PAR_STILL_SENS,
@@ -58,6 +60,7 @@ class LD2410(Device):
         """Ensure connection and refresh configuration parameters."""
         await self._ensure_connected()
         params = await self.cmd_read_params()
+        res = await self.cmd_get_resolution()
         self._update_parsed_data(
             {
                 "move_gate_sensitivity": params.get("move_gate_sensitivity"),
@@ -65,6 +68,7 @@ class LD2410(Device):
                 "absence_delay": params.get("absence_delay"),
                 "max_move_gate": params.get("max_move_gate"),
                 "max_still_gate": params.get("max_still_gate"),
+                "resolution": res,
             }
         )
 
@@ -236,6 +240,29 @@ class LD2410(Device):
         if response != b"\x00\x00":
             raise OperationError("Failed to set absence delay")
         self._update_parsed_data({"absence_delay": delay})
+        await self.cmd_end_config()
+
+    async def cmd_get_resolution(self) -> int:
+        """Query the distance resolution."""
+        await self.cmd_enable_config()
+        response = await self._send_command(CMD_GET_RES)
+        if not response or len(response) < 4 or response[:2] != b"\x00\x00":
+            raise OperationError("Failed to get resolution")
+        idx = int.from_bytes(response[2:4], "little")
+        await self.cmd_end_config()
+        self._update_parsed_data({"resolution": idx})
+        return idx
+
+    async def cmd_set_resolution(self, index: int) -> None:
+        """Set the distance resolution."""
+        if index not in (0, 1):
+            raise ValueError("index must be 0 or 1")
+        await self.cmd_enable_config()
+        payload = index.to_bytes(2, "little").hex()
+        response = await self._send_command(CMD_SET_RES + payload)
+        if response != b"\x00\x00":
+            raise OperationError("Failed to set resolution")
+        self._update_parsed_data({"resolution": index})
         await self.cmd_end_config()
 
     def _parse_uplink_frame(self, data: bytes) -> Dict[str, Any] | None:

--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -269,9 +269,11 @@ class LD2410(Device):
 
     async def cmd_reboot(self) -> None:
         """Reboot the module."""
+        await self.cmd_enable_config()
         response = await self._send_command(CMD_REBOOT)
         if response != b"\x00\x00":
             raise OperationError("Failed to reboot")
+        await self.cmd_end_config()
 
     def _parse_uplink_frame(self, data: bytes) -> Dict[str, Any] | None:
         """Parse an uplink frame.

--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -13,6 +13,7 @@ from ..const import (
     CMD_ENABLE_CFG,
     CMD_END_CFG,
     CMD_ENABLE_ENGINEERING,
+    CMD_REBOOT,
     CMD_READ_PARAMS,
     CMD_START_AUTO_THRESH,
     CMD_QUERY_AUTO_THRESH,
@@ -264,6 +265,13 @@ class LD2410(Device):
             raise OperationError("Failed to set resolution")
         self._update_parsed_data({"resolution": index})
         await self.cmd_end_config()
+        await self.cmd_reboot()
+
+    async def cmd_reboot(self) -> None:
+        """Reboot the module."""
+        response = await self._send_command(CMD_REBOOT)
+        if response != b"\x00\x00":
+            raise OperationError("Failed to reboot")
 
     def _parse_uplink_frame(self, data: bytes) -> Dict[str, Any] | None:
         """Parse an uplink frame.

--- a/custom_components/ld2410/select.py
+++ b/custom_components/ld2410/select.py
@@ -1,0 +1,59 @@
+"""Select entities for configuration."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+try:
+    from homeassistant.helpers.entity_platform import (
+        AddConfigEntryEntitiesCallback,
+    )
+except ImportError:  # Home Assistant <2024.6
+    from homeassistant.helpers.entity_platform import (
+        AddEntitiesCallback as AddConfigEntryEntitiesCallback,
+    )
+
+from .coordinator import ConfigEntryType, DataCoordinator
+from .entity import Entity, exception_handler
+
+PARALLEL_UPDATES = 0
+
+OPTIONS = ["0.75 m", "0.20 m"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntryType,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up select entities from config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities([ResolutionSelect(coordinator)])
+
+
+class ResolutionSelect(Entity, SelectEntity):
+    """Representation of the distance resolution setting."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = OPTIONS
+    _attr_entity_registry_enabled_default = True
+    _attr_icon = "mdi:tape-measure"
+    _attr_translation_key = "distance_resolution"
+
+    def __init__(self, coordinator: DataCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}-resolution"
+
+    @property
+    def current_option(self) -> str | None:
+        idx = self.parsed_data.get("resolution")
+        if idx is None or idx >= len(self.options):
+            return None
+        return self.options[idx]
+
+    @exception_handler
+    async def async_select_option(self, option: str) -> None:
+        index = self.options.index(option)
+        await self._device.cmd_set_resolution(index)

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -31,6 +31,7 @@
     "entity": {
         "binary_sensor": {"door_timeout": {"name": "Timeout"}},
         "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "select": {"distance_resolution": {"name": "Distance resolution"}},
         "sensor": {
             "bluetooth_signal": {"name": "Bluetooth signal"},
             "wifi_signal": {"name": "Wi-Fi signal"},

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -1,5 +1,8 @@
 {
-    "entity": {"button": {"auto_threshold": {"name": "Auto threshold"}}},
+    "entity": {
+        "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "select": {"distance_resolution": {"name": "Distance resolution"}}
+    },
     "exceptions": {
         "operation_error": {
             "message": "An error occurred while performing the action: {error}"

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -436,6 +436,8 @@ async def test_set_resolution_success() -> None:
             b"\x00\x00\x01\x00\x00@",
             b"\x00\x00",
             b"\x00\x00",
+            b"\x00\x00\x01\x00\x00@",
+            b"\x00\x00",
             b"\x00\x00",
         ],
     )
@@ -444,7 +446,9 @@ async def test_set_resolution_success() -> None:
         CMD_ENABLE_CFG + "0001",
         CMD_SET_RES + "0100",
         CMD_END_CFG,
+        CMD_ENABLE_CFG + "0001",
         CMD_REBOOT,
+        CMD_END_CFG,
     ]
     assert dev.parsed_data["resolution"] == 1
 
@@ -457,7 +461,6 @@ async def test_set_resolution_fail() -> None:
         response=[
             b"\x00\x00\x01\x00\x00@",
             b"\x01\x00",
-            b"\x00\x00",
         ],
     )
     with pytest.raises(OperationError):
@@ -468,17 +471,31 @@ async def test_set_resolution_fail() -> None:
 @pytest.mark.asyncio
 async def test_reboot_success() -> None:
     """Reboot command sends correct key."""
-    dev = _TestDevice(password=None, response=b"\x00\x00")
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x00\x00",
+            b"\x00\x00",
+        ],
+    )
     await dev.cmd_reboot()
-    assert dev.last_key == CMD_REBOOT
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_REBOOT, CMD_END_CFG]
 
 
 @pytest.mark.asyncio
 async def test_reboot_fail() -> None:
     """Reboot command raises on failure."""
-    dev = _TestDevice(password=None, response=b"\x01\x00")
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x01\x00",
+        ],
+    )
     with pytest.raises(OperationError):
         await dev.cmd_reboot()
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_REBOOT]
 
 
 def test_unwrap_response():

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -21,6 +21,7 @@ from custom_components.ld2410.api.const import (
     CMD_SET_MAX_GATES_AND_NOBODY,
     CMD_SET_SENSITIVITY,
     CMD_READ_PARAMS,
+    CMD_REBOOT,
     CMD_SET_RES,
     CMD_GET_RES,
     PAR_MAX_MOVE_GATE,
@@ -435,10 +436,16 @@ async def test_set_resolution_success() -> None:
             b"\x00\x00\x01\x00\x00@",
             b"\x00\x00",
             b"\x00\x00",
+            b"\x00\x00",
         ],
     )
     await dev.cmd_set_resolution(1)
-    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_SET_RES + "0100", CMD_END_CFG]
+    assert dev.keys == [
+        CMD_ENABLE_CFG + "0001",
+        CMD_SET_RES + "0100",
+        CMD_END_CFG,
+        CMD_REBOOT,
+    ]
     assert dev.parsed_data["resolution"] == 1
 
 
@@ -456,6 +463,22 @@ async def test_set_resolution_fail() -> None:
     with pytest.raises(OperationError):
         await dev.cmd_set_resolution(1)
     assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_SET_RES + "0100"]
+
+
+@pytest.mark.asyncio
+async def test_reboot_success() -> None:
+    """Reboot command sends correct key."""
+    dev = _TestDevice(password=None, response=b"\x00\x00")
+    await dev.cmd_reboot()
+    assert dev.last_key == CMD_REBOOT
+
+
+@pytest.mark.asyncio
+async def test_reboot_fail() -> None:
+    """Reboot command raises on failure."""
+    dev = _TestDevice(password=None, response=b"\x01\x00")
+    with pytest.raises(OperationError):
+        await dev.cmd_reboot()
 
 
 def test_unwrap_response():

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -21,6 +21,8 @@ from custom_components.ld2410.api.const import (
     CMD_SET_MAX_GATES_AND_NOBODY,
     CMD_SET_SENSITIVITY,
     CMD_READ_PARAMS,
+    CMD_SET_RES,
+    CMD_GET_RES,
     PAR_MAX_MOVE_GATE,
     PAR_MAX_STILL_GATE,
     PAR_NOBODY_DURATION,
@@ -319,6 +321,9 @@ async def test_connect_and_update_reads_params() -> None:
         + b"\x02" * 9
         + b"\x1e\x00",
         b"\x00\x00",
+        b"\x00\x00\x01\x00\x00@",
+        b"\x00\x00\x00\x00",
+        b"\x00\x00",
     ]
     dev = _TestDevice(password=None, response=resp)
     dev._ensure_connected = AsyncMock(side_effect=dev.cmd_enable_engineering_mode)
@@ -330,10 +335,14 @@ async def test_connect_and_update_reads_params() -> None:
         CMD_ENABLE_CFG + "0001",
         CMD_READ_PARAMS,
         CMD_END_CFG,
+        CMD_ENABLE_CFG + "0001",
+        CMD_GET_RES,
+        CMD_END_CFG,
     ]
     assert dev.parsed_data["move_gate_sensitivity"] == [1] * 9
     assert dev.parsed_data["still_gate_sensitivity"] == [2] * 9
     assert dev.parsed_data["absence_delay"] == 30
+    assert dev.parsed_data["resolution"] == 0
 
 
 @pytest.mark.asyncio
@@ -384,6 +393,69 @@ async def test_set_absence_delay_fail() -> None:
         + "1e000000"
     )
     assert dev.keys == [CMD_ENABLE_CFG + "0001", expected_payload]
+
+
+@pytest.mark.asyncio
+async def test_get_resolution_success() -> None:
+    """Get resolution command parses response."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x00\x00\x01\x00",
+            b"\x00\x00",
+        ],
+    )
+    res = await dev.cmd_get_resolution()
+    assert res == 1
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_GET_RES, CMD_END_CFG]
+
+
+@pytest.mark.asyncio
+async def test_get_resolution_fail() -> None:
+    """Get resolution command raises on failure."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x01\x00\x01\x00",
+        ],
+    )
+    with pytest.raises(OperationError):
+        await dev.cmd_get_resolution()
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_GET_RES]
+
+
+@pytest.mark.asyncio
+async def test_set_resolution_success() -> None:
+    """Set resolution command sends correct key."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x00\x00",
+            b"\x00\x00",
+        ],
+    )
+    await dev.cmd_set_resolution(1)
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_SET_RES + "0100", CMD_END_CFG]
+    assert dev.parsed_data["resolution"] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_resolution_fail() -> None:
+    """Set resolution command raises on failure."""
+    dev = _TestDevice(
+        password=None,
+        response=[
+            b"\x00\x00\x01\x00\x00@",
+            b"\x01\x00",
+            b"\x00\x00",
+        ],
+    )
+    with pytest.raises(OperationError):
+        await dev.cmd_set_resolution(1)
+    assert dev.keys == [CMD_ENABLE_CFG + "0001", CMD_SET_RES + "0100"]
 
 
 def test_unwrap_response():

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -25,6 +25,7 @@ async def test_reconnect_after_unexpected_disconnect():
             "absence_delay": 0,
         }
     )
+    device.cmd_get_resolution = AsyncMock(return_value=0)
     device._update_parsed_data = MagicMock()
 
     with (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -160,6 +160,10 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
             ),
         ),
         patch(
+            "custom_components.ld2410.api.LD2410.cmd_get_resolution",
+            AsyncMock(return_value=0),
+        ),
+        patch(
             "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",
             autospec=True,
         ),
@@ -217,6 +221,10 @@ async def test_unload_disconnects_device(hass: HomeAssistant) -> None:
                     "absence_delay": 0,
                 }
             ),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_get_resolution",
+            AsyncMock(return_value=0),
         ),
         patch(
             "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,73 @@
+"""Test the resolution select entity."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from custom_components.ld2410.const import DOMAIN
+
+from . import LD2410b_SERVICE_INFO
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:  # Home Assistant <2023.9
+    from .mocks import MockConfigEntry
+
+try:
+    from tests.components.bluetooth import inject_bluetooth_service_info
+except ImportError:  # Home Assistant <2023.9
+    from .mocks import inject_bluetooth_service_info
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_resolution_select(hass: HomeAssistant) -> None:
+    """Test resolution select entity."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value={"resolution": 0}),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_resolution",
+            AsyncMock(),
+        ) as set_mock,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        entity_id = "select.test_name_distance_resolution"
+        state = hass.states.get(entity_id)
+        assert state and state.state == "0.75 m"
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "0.20 m"},
+            blocking=True,
+        )
+        set_mock.assert_awaited_once_with(1)


### PR DESCRIPTION
## Summary
- support querying and setting distance resolution
- expose resolution as a selectable configuration entity with icon
- test new resolution functionality and configuration select

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components/ld2410`


------
https://chatgpt.com/codex/tasks/task_e_68b09e8ebb2883308b0817509c2c65f7