### PR TITLE
Add light function select and sensitivity slider

### DIFF
--- a/custom_components/ld2410/api/const/__init__.py
+++ b/custom_components/ld2410/api/const/__init__.py
@@ -1,6 +1,7 @@
 """Device constants library."""
 
-# Obtained from the protocol documentation in https://h.hlktech.com/download/HLK-LD2410C-24G/1/LD2410C%20%E4%B8%B2%E5%8F%A3%E9%80%9A%E4%BF%A1%E5%8D%8F%E8%AE%AE%20V1.09.pdf
+# Obtained from the protocol documentation in
+# https://h.hlktech.com/download/HLK-LD2410C-24G/1/LD2410C%20%E4%B8%B2%E5%8F%A3%E9%80%9A%E4%BF%A1%E5%8D%8F%E8%AE%AE%20V1.09.pdf
 
 from __future__ import annotations
 
@@ -14,163 +15,170 @@ CHARACTERISTIC_NOTIFY = "0000fff1-0000-1000-8000-00805f9b34fb"
 CHARACTERISTIC_WRITE = "0000fff2-0000-1000-8000-00805f9b34fb"
 
 # ---------- Frame constants (hex strings) ----------
-TX_HEADER = "FDFCFBFA"  # Downlink (host→radar) command frame header. Command/ACK use same header/footer.
-TX_FOOTER = "04030201"  # Downlink frame footer. ACK frames use this too.  status(2): "0000"=success, "0100"=failure.
+TX_HEADER = "FDFCFBFA"  # Downlink (host→radar) command frame header. Command/ACK share header/footer.
+TX_FOOTER = "04030201"  # Downlink frame footer. ACK frames use this too. status(2): "0000"=success, "0100"=failure.
 RX_HEADER = "F4F3F2F1"  # Uplink (radar→host) data frame header. Types: "01"=engineering, "02"=basic.
 RX_FOOTER = "F8F7F6F5"  # Uplink data frame footer.
 
-# NOTE on ACKs: ACK uplink frame data begins with (sent_cmd | 0x0100) then the return payload.
+# NOTE on ACKs: ACK uplink data begins with (sent_cmd | 0x0100) then the return payload.
 # Example: send "FE00" → ACK contains "FE01" then status(2).
 
 # ---------- Command words (hex strings, little-endian) ----------
 
-# Enable configuration session (must precede other config commands). Returns status + protocol version + buffer size.
+# Enable configuration session. Returns status + protocol version + buffer size.
 CMD_ENABLE_CFG = "FF00"  # value: "0001"
 # return: status(2) + proto_ver(2="0001") + buf_size(2="4000"). "0000"=OK, "0100"=fail.
 
-# End configuration session (resume normal working mode).
+# End configuration session (resume normal mode).
 CMD_END_CFG = "FE00"  # value: (none)
-# return: status(2). Send again CMD_ENABLE_CFG to re-enter config mode.
+# return: status(2).
 
-# Set max detection gates (move & still) and "no-one" duration (absence delay).
+# Set max detection gates (move & still) and absence delay (“nobody”).
+# Requires Config: YES                                 |  Reboot: NO (applies immediately, persists)
 CMD_SET_MAX_GATES_AND_NOBODY = "6000"
 # value (all words little-endian, values are u32 LE):
 #   "0000"+<u32 move_gate 2..8>  +  "0100"+<u32 still_gate 2..8>  +  "0200"+<u32 nobody_sec 0..65535>
-# return: status(2). Takes effect immediately; retained across power-cycles. Defaults in Table 7.
+# return: status(2).
 
-# Read current configuration (gates, per-gate sensitivities, unoccupied duration).
+# Read current configuration (gates, per-gate sensitivities, absence delay).
+# Requires Config: YES                                 |  Reboot: NO
 CMD_READ_PARAMS = "6100"  # value: (none)
 # return: status(2) + "AA"(1B) + N_max(1B) + cfg_max_move(1B) + cfg_max_still(1B)
 #       + move_sens[0..N](1B each) + still_sens[0..N](1B each) + absence_delay(2).
 
-# Enable engineering mode (uplink adds per-gate energy arrays, data type "01").
+# Enable engineering mode (uplink type "01" with per-gate energies).
+# Requires Config: YES                                 |  Reboot: NO (volatile; clears on power-up)
 CMD_ENABLE_ENGINEERING = "6200"  # value: (none)
-# return: status(2). Setting is volatile (lost on power-off).
+# return: status(2).
 
-# Disable engineering mode (uplink reverts to basic target info, data type "02").
+# Disable engineering mode (revert to uplink type "02" basic).
+# Requires Config: YES                                 |  Reboot: NO
 CMD_DISABLE_ENGINEERING = "6300"  # value: (none)
 # return: status(2).
 
-# Set sensitivities for a specific gate or all gates.
+# Set sensitivities for a specific gate or for all gates.
+# Requires Config: YES                                 |  Reboot: NO (applies immediately, persists)
 CMD_SET_SENSITIVITY = "6400"
 # value:
 #   "0000"+<u32 gate_id 0..8 or 0x0000FFFF for ALL> + "0100"+<u32 move 0..100> + "0200"+<u32 still 0..100>
-# return: status(2). Use ALL ("FFFF") to apply uniform values to every gate.
+# return: status(2).
 
 # Read firmware version (type, major, minor/build).
+# Requires Config: YES                                 |  Reboot: NO
 CMD_READ_FW = "A000"  # value: (none)
-# return: status(2) + fw_type(2="0001") + major(2) + minor(4). Example decodes to Vx.y.yyyymmddhh.
+# return: status(2) + fw_type(2="0001") + major(2) + minor(4).
 
 # Set UART baud rate (persists; takes effect after reboot).
-CMD_SET_BAUD = "A100"  # value: BAUD_* index(2)
+# Requires Config: YES                                 |  Reboot: REQUIRED (to apply new baud)
+CMD_SET_BAUD = "A100"  # value: BAUD_* index(2, LE)
 # return: status(2). Indices: "0001"=9600 … "0008"=460800; factory default "0007"=256000.
 
-# Restore factory defaults (persists; takes effect after reboot).
+# Restore factory defaults (persists; applied after reboot).
+# Requires Config: YES                                 |  Reboot: REQUIRED (settings take effect after reboot)
 CMD_FACTORY_RESET = "A200"  # value: (none)
-# return: status(2). Table 7 lists default gates/sensitivities/baud.
+# return: status(2).
 
-# Reboot module (module restarts after ACK).
+# Reboot module (restarts immediately after ACK).
+# Requires Config: YES                                 |  Reboot: (this command causes the reboot)
 CMD_REBOOT = "A300"  # value: (none)
 # return: status(2).
 
-# Bluetooth on/off (requires reboot to apply).
+# Bluetooth on/off (persisted; requires reboot to apply).
+# Requires Config: YES                                 |  Reboot: REQUIRED
 CMD_BT_ONOFF = "A400"  # value: "0001"=ON, "0000"=OFF
 # return: status(2). BT is ON by default.
 
 # Get MAC address (over UART).
+# Requires Config: YES                                 |  Reboot: NO
 CMD_GET_MAC = "A500"  # value: "0001"
-# return: status(2) + fixed_type(1B="00") + MAC(6B; shown big-endian in example).
+# return: status(2) + fixed_type(1B="00") + MAC(6B; displayed big-endian).
 
-# Obtain Bluetooth permission (checks password) — reply is sent via Bluetooth, not UART.
-CMD_BT_GET_PERMISSION = (
-    "A800"  # value: 6B password ("4869 4C69 6E6B" for "HiLink" split in LE pairs)
-)
-# return: status(2). Treat "0000"=allowed, "0100"=denied (per generic success/fail).
+# Obtain Bluetooth permission (password check).
+# Requires Config: NO                                  |  Reboot: NO
+# NOTE: Reply/ACK is sent **over Bluetooth only**, not over UART.
+CMD_BT_GET_PERMISSION = "A800"  # value: 6B password (3×u16 LE; e.g. "HiLink" → 4869 4C69 6E6B)
+# return: status(2) over BLE; "0000"=allowed, non-zero=denied.
 
 # Set Bluetooth password (stores new 6B password).
-CMD_BT_SET_PWD = "A900"  # value: 6B password (small-end order)
+# Requires Config: YES                                 |  Reboot: NO
+CMD_BT_SET_PWD = "A900"  # value: 6B password (little-end pairs)
 # return: status(2).
 
-# Set distance resolution per gate (0.75 m or 0.2 m; persists; needs reboot).
-CMD_SET_RES = "AA00"  # value: RES_* index(2)
-# return: status(2). "0000"→0.75 m; "0001"→0.20 m. Example shows index "0001".
+# Set distance resolution per gate (0.75 m or 0.2 m).
+# Requires Config: YES                                 |  Reboot: REQUIRED (to apply resolution)
+CMD_SET_RES = "AA00"  # value: RES_* index(2, LE)
+# return: status(2). "0000"→0.75 m; "0001"→0.20 m.
 
 # Query distance resolution (returns current index).
+# Requires Config: YES                                 |  Reboot: NO
 CMD_GET_RES = "AB00"  # value: (none)
-# return: status(2) + RES_* index(2). Example ACK shows "... 0001 00" → 0.2 m per gate.
+# return: status(2) + RES_* index(2).
 
-# Set auxiliary control (ambient light sensor & output config).
-CMD_SET_AUX = "AD00"  # value: 4B config = [mode(1B) + threshold(1B) + out_level(1B) + reserved(1B)]
-# return: status(2). Modes: 0x00=disable light sensor control (OUT always triggered by presence),
-#        0x01=enable (OUT active only if ambient light < threshold), 0x02=enable (OUT active only if ambient light > threshold).
-#        Out_level: 0x00=OUT default low (active high on detect), 0x01=OUT default high (active low on detect).
+# Set auxiliary control (ambient light & OUT polarity/threshold).
+# Requires Config: YES                                 |  Reboot: NO (applies immediately, persists)
+CMD_SET_AUX = "AD00"  # value: 4B config = [mode(1B), threshold(1B), out_level(1B), reserved(1B)]
+# return: status(2).
+#   Modes: 0x00=disabled; 0x01=OUT active if light<threshold; 0x02=OUT active if light>threshold.
+#   out_level: 0x00=OUT idle low (active-high on detect), 0x01=OUT idle high (active-low on detect).
 
 # Read auxiliary control configuration.
+# Requires Config: YES                                 |  Reboot: NO
 CMD_GET_AUX = "AE00"  # value: (none)
-# return: status(2) + 4B config (same format as CMD_SET_AUX).
+# return: status(2) + 4B config (same layout as CMD_SET_AUX).
 
 # Start automatic threshold detection (background noise calibration).
-CMD_START_AUTO_THRESH = "0B00"  # value: <u16 duration_sec> (detection time in seconds)
-# return: status(2). Sensor performs background noise detection for the given duration, then auto-adjusts sensitivities.
+# Requires Config: YES                                 |  Reboot: NO
+CMD_START_AUTO_THRESH = "0B00"  # value: <u16 duration_sec> (LE)
+# return: status(2). Device samples background noise then auto-adjusts sensitivities.
 
 # Query status of automatic threshold detection.
+# Requires Config: YES                                 |  Reboot: NO
 CMD_QUERY_AUTO_THRESH = "1B00"  # value: (none)
-# return: status(2) + status_code(2). 0x0000 = not in progress, 0x0001 = in progress, 0x0002 = completed (calibration done).
+# return: status(2) + status_code(2): 0000=idle, 0001=in-progress, 0002=completed.
 
 # ---------- Parameter words (for 0x0060 “max gates & nobody”) ----------
-PAR_MAX_MOVE_GATE = "0000"  # u32 move gate: 2..8
+PAR_MAX_MOVE_GATE = "0000"   # u32 move gate: 2..8
 PAR_MAX_STILL_GATE = "0100"  # u32 still gate: 2..8
-PAR_NOBODY_DURATION = "0200"  # u32 seconds: 0..65535  (aka "no-one duration").
+PAR_NOBODY_DURATION = "0200" # u32 seconds: 0..65535 (aka absence_delay).
 
 # ---------- Parameter words (for 0x0064 “set sensitivity”) ----------
-PAR_DISTANCE_GATE = "0000"  # u32 gate: 0..8, or ALL_GATES
-PAR_MOVE_SENS = "0100"  # u32 sensitivity: 0..100
-PAR_STILL_SENS = "0200"  # u32 sensitivity: 0..100
-ALL_GATES = "FFFF"  # special selector meaning "apply to all gates".
+PAR_DISTANCE_GATE = "0000"   # u32 gate: 0..8, or ALL_GATES
+PAR_MOVE_SENS = "0100"       # u32 sensitivity: 0..100
+PAR_STILL_SENS = "0200"      # u32 sensitivity: 0..100
+ALL_GATES = "FFFF"           # special selector meaning "apply to all gates" (u32 value = 0x0000FFFF LE → FF FF 00 00).
 
 # ---------- Baud rate indices (for CMD_SET_BAUD A100) ----------
-BAUD_9600 = "0001"
-BAUD_19200 = "0002"
-BAUD_38400 = "0003"
-BAUD_57600 = "0004"
+BAUD_9600   = "0001"
+BAUD_19200  = "0002"
+BAUD_38400  = "0003"
+BAUD_57600  = "0004"
 BAUD_115200 = "0005"
 BAUD_230400 = "0006"
 BAUD_256000 = "0007"  # factory default
-BAUD_460800 = "0008"  # per Table 6.
+BAUD_460800 = "0008"
 
 # ---------- Distance resolution indices (for CMD_SET_RES / CMD_GET_RES) ----------
 RES_PER_GATE_0_75M = "0000"  # each distance gate = 0.75 m
-RES_PER_GATE_0_2M = (
-    "0001"  # each distance gate = 0.20 m  (query example returns "0001").
-)
+RES_PER_GATE_0_2M  = "0001"  # each distance gate = 0.20 m
 
 # ---------- Auxiliary control function values (for CMD_SET_AUX / CMD_GET_AUX) ----------
-LIGHT_CONTROL_OFF = "00"  # 0x00 = Disable light-sensing control (ambient light ignored)
-LIGHT_CONTROL_ENABLE_UNDER = (
-    "01"  # 0x01 = Enable aux control (OUT active if ambient < threshold)
-)
-LIGHT_CONTROL_ENABLE_OVER = (
-    "02"  # 0x02 = Enable aux control (OUT active if ambient > threshold)
-)
-LIGHT_THRESHOLD_DEFAULT = "80"  # Default light threshold = 0x80 (128)
-OUT_LEVEL_LOW = (
-    "00"  # 0x00 = OUT default low (outputs low when idle, high when target detected)
-)
-OUT_LEVEL_HIGH = (
-    "01"  # 0x01 = OUT default high (outputs high when idle, low when target detected)
-)
+LIGHT_CONTROL_OFF          = "00"  # disable ambient-light gating of OUT
+LIGHT_CONTROL_ENABLE_UNDER = "01"  # OUT active if ambient < threshold
+LIGHT_CONTROL_ENABLE_OVER  = "02"  # OUT active if ambient > threshold
+LIGHT_THRESHOLD_DEFAULT    = "80"  # default threshold (0x80 = 128)
+
+# Prefer polarity names that describe behavior on detection:
+OUT_ACTIVE_HIGH = "00"  # OUT idle low, goes high on detect (a.k.a. “default low”)
+OUT_ACTIVE_LOW  = "01"  # OUT idle high, goes low on detect (a.k.a. “default high”)
 
 # ---------- Uplink data types (for RX payload interpretation) ----------
-UPLINK_TYPE_ENGINEERING = "01"  # per-gate energies appended to basic target info
-UPLINK_TYPE_BASIC = "02"  # basic target info only (default).
-
+UPLINK_TYPE_ENGINEERING = "01"  # per-gate energies appended to basic target info (+ light_value, out_state)
+UPLINK_TYPE_BASIC       = "02"  # basic target info only (default).
 
 class Model(StrEnum):
     """Device models."""
-
     LD2410 = "HLK-LD2410"
     # Additional models (e.g., LD2410B, LD2410C) can be represented by the same commands
-
 
 __all__ = [
     # exports
@@ -232,8 +240,8 @@ __all__ = [
     "LIGHT_CONTROL_ENABLE_UNDER",
     "LIGHT_CONTROL_ENABLE_OVER",
     "LIGHT_THRESHOLD_DEFAULT",
-    "OUT_LEVEL_LOW",
-    "OUT_LEVEL_HIGH",
+    "OUT_ACTIVE_HIGH",
+    "OUT_ACTIVE_LOW",
     # uplink data types
     "UPLINK_TYPE_ENGINEERING",
     "UPLINK_TYPE_BASIC",

--- a/custom_components/ld2410/number.py
+++ b/custom_components/ld2410/number.py
@@ -130,4 +130,4 @@ class LightSensitivityNumber(Entity, NumberEntity):
 
     @exception_handler
     async def async_set_native_value(self, value: float) -> None:
-        await self._device.cmd_set_light_threshold(int(value))
+        await self._device.cmd_set_light_config(threshold=int(value))

--- a/custom_components/ld2410/number.py
+++ b/custom_components/ld2410/number.py
@@ -42,6 +42,7 @@ async def async_setup_entry(
             GateSensitivityNumber(coordinator, "still_gate_sensitivity", gate)
         )
     entities.append(AbsenceDelayNumber(coordinator))
+    entities.append(LightSensitivityNumber(coordinator))
     async_add_entities(entities)
 
 
@@ -106,3 +107,27 @@ class AbsenceDelayNumber(Entity, NumberEntity):
     @exception_handler
     async def async_set_native_value(self, value: float) -> None:
         await self._device.cmd_set_absence_delay(int(value))
+
+
+class LightSensitivityNumber(Entity, NumberEntity):
+    """Representation of light sensitivity slider."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0
+    _attr_native_max_value = 255
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:brightness-6"
+    _attr_translation_key = "light_sensitivity"
+
+    def __init__(self, coordinator: DataCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}-light_sensitivity"
+
+    @property
+    def native_value(self) -> int | None:
+        return self.parsed_data.get("light_threshold")
+
+    @exception_handler
+    async def async_set_native_value(self, value: float) -> None:
+        await self._device.cmd_set_light_threshold(int(value))

--- a/custom_components/ld2410/select.py
+++ b/custom_components/ld2410/select.py
@@ -21,7 +21,7 @@ from .entity import Entity, exception_handler
 PARALLEL_UPDATES = 0
 
 OPTIONS = ["0.75 m", "0.20 m"]
-LIGHT_OPTIONS = ["off", "on"]
+LIGHT_OPTIONS = ["off", "dimmer than", "brighter than"]
 
 
 async def async_setup_entry(
@@ -63,7 +63,7 @@ class ResolutionSelect(Entity, SelectEntity):
 
 
 class LightFunctionSelect(Entity, SelectEntity):
-    """Representation of light function on/off."""
+    """Representation of light control mode."""
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_options = LIGHT_OPTIONS
@@ -77,11 +77,12 @@ class LightFunctionSelect(Entity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        enabled = self.parsed_data.get("light_function")
-        if enabled is None:
+        mode = self.parsed_data.get("light_function")
+        if mode is None or mode >= len(self.options):
             return None
-        return "on" if enabled else "off"
+        return self.options[mode]
 
     @exception_handler
     async def async_select_option(self, option: str) -> None:
-        await self._device.cmd_set_light_function(option == "on")
+        index = self.options.index(option)
+        await self._device.cmd_set_light_function(index)

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -33,7 +33,8 @@
         "button": {"auto_threshold": {"name": "Auto threshold"}},
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
-            "light_function": {"name": "Light function"}
+            "light_function": {"name": "Light function"},
+            "out_level": {"name": "OUT level"}
         },
         "number": {"light_sensitivity": {"name": "Light sensitivity"}},
         "sensor": {

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -31,7 +31,11 @@
     "entity": {
         "binary_sensor": {"door_timeout": {"name": "Timeout"}},
         "button": {"auto_threshold": {"name": "Auto threshold"}},
-        "select": {"distance_resolution": {"name": "Distance resolution"}},
+        "select": {
+            "distance_resolution": {"name": "Distance resolution"},
+            "light_function": {"name": "Light function"}
+        },
+        "number": {"light_sensitivity": {"name": "Light sensitivity"}},
         "sensor": {
             "bluetooth_signal": {"name": "Bluetooth signal"},
             "wifi_signal": {"name": "Wi-Fi signal"},

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -1,7 +1,11 @@
 {
     "entity": {
         "button": {"auto_threshold": {"name": "Auto threshold"}},
-        "select": {"distance_resolution": {"name": "Distance resolution"}}
+        "select": {
+            "distance_resolution": {"name": "Distance resolution"},
+            "light_function": {"name": "Light function"}
+        },
+        "number": {"light_sensitivity": {"name": "Light sensitivity"}}
     },
     "exceptions": {
         "operation_error": {

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -3,7 +3,8 @@
         "button": {"auto_threshold": {"name": "Auto threshold"}},
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
-            "light_function": {"name": "Light function"}
+            "light_function": {"name": "Light function"},
+            "out_level": {"name": "OUT level"}
         },
         "number": {"light_sensitivity": {"name": "Light sensitivity"}}
     },

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -352,7 +352,7 @@ async def test_connect_and_update_reads_params() -> None:
     assert dev.parsed_data["absence_delay"] == 30
     assert dev.parsed_data["resolution"] == 0
     assert dev.parsed_data["light_threshold"] == 100
-    assert dev.parsed_data["light_function"] is True
+    assert dev.parsed_data["light_function"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -353,6 +353,7 @@ async def test_connect_and_update_reads_params() -> None:
     assert dev.parsed_data["resolution"] == 0
     assert dev.parsed_data["light_threshold"] == 100
     assert dev.parsed_data["light_function"] == 1
+    assert dev.parsed_data["light_out_level"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -24,6 +24,7 @@ from custom_components.ld2410.api.const import (
     CMD_REBOOT,
     CMD_SET_RES,
     CMD_GET_RES,
+    CMD_GET_AUX,
     PAR_MAX_MOVE_GATE,
     PAR_MAX_STILL_GATE,
     PAR_NOBODY_DURATION,
@@ -325,6 +326,9 @@ async def test_connect_and_update_reads_params() -> None:
         b"\x00\x00\x01\x00\x00@",
         b"\x00\x00\x00\x00",
         b"\x00\x00",
+        b"\x00\x00\x01\x00\x00@",
+        b"\x00\x00\x01\x64\x00\x00",
+        b"\x00\x00",
     ]
     dev = _TestDevice(password=None, response=resp)
     dev._ensure_connected = AsyncMock(side_effect=dev.cmd_enable_engineering_mode)
@@ -339,11 +343,16 @@ async def test_connect_and_update_reads_params() -> None:
         CMD_ENABLE_CFG + "0001",
         CMD_GET_RES,
         CMD_END_CFG,
+        CMD_ENABLE_CFG + "0001",
+        CMD_GET_AUX,
+        CMD_END_CFG,
     ]
     assert dev.parsed_data["move_gate_sensitivity"] == [1] * 9
     assert dev.parsed_data["still_gate_sensitivity"] == [2] * 9
     assert dev.parsed_data["absence_delay"] == 30
     assert dev.parsed_data["resolution"] == 0
+    assert dev.parsed_data["light_threshold"] == 100
+    assert dev.parsed_data["light_function"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -26,6 +26,7 @@ async def test_reconnect_after_unexpected_disconnect():
         }
     )
     device.cmd_get_resolution = AsyncMock(return_value=0)
+    device.cmd_get_light_config = AsyncMock()
     device._update_parsed_data = MagicMock()
 
     with (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -164,6 +164,10 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
             AsyncMock(return_value=0),
         ),
         patch(
+            "custom_components.ld2410.api.LD2410.cmd_get_light_config",
+            AsyncMock(),
+        ),
+        patch(
             "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",
             autospec=True,
         ),
@@ -225,6 +229,10 @@ async def test_unload_disconnects_device(hass: HomeAssistant) -> None:
         patch(
             "custom_components.ld2410.api.LD2410.cmd_get_resolution",
             AsyncMock(return_value=0),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_get_light_config",
+            AsyncMock(),
         ),
         patch(
             "custom_components.ld2410.api.devices.device.BaseDevice._update_parsed_data",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -144,10 +144,16 @@ async def test_light_sensitivity_number(hass: HomeAssistant) -> None:
         patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
-            AsyncMock(return_value={"light_threshold": 128, "light_function": 1}),
+            AsyncMock(
+                return_value={
+                    "light_threshold": 128,
+                    "light_function": 1,
+                    "light_out_level": 0,
+                }
+            ),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.cmd_set_light_threshold",
+            "custom_components.ld2410.api.LD2410.cmd_set_light_config",
             AsyncMock(),
         ) as set_mock,
     ):
@@ -166,4 +172,4 @@ async def test_light_sensitivity_number(hass: HomeAssistant) -> None:
             {"entity_id": entity_id, "value": 200},
             blocking=True,
         )
-        set_mock.assert_awaited_once_with(200)
+        set_mock.assert_awaited_once_with(threshold=200)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -144,7 +144,7 @@ async def test_light_sensitivity_number(hass: HomeAssistant) -> None:
         patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
-            AsyncMock(return_value={"light_threshold": 128, "light_function": True}),
+            AsyncMock(return_value={"light_threshold": 128, "light_function": 1}),
         ),
         patch(
             "custom_components.ld2410.api.LD2410.cmd_set_light_threshold",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -71,3 +71,55 @@ async def test_resolution_select(hass: HomeAssistant) -> None:
             blocking=True,
         )
         set_mock.assert_awaited_once_with(1)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_light_function_select(hass: HomeAssistant) -> None:
+    """Test light function select entity."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value={"light_function": True, "light_threshold": 100}),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_light_function",
+            AsyncMock(),
+        ) as set_mock,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        entity_id = "select.test_name_light_function"
+        state = hass.states.get(entity_id)
+        assert state and state.state == "on"
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "off"},
+            blocking=True,
+        )
+        set_mock.assert_awaited_once_with(False)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -100,10 +100,16 @@ async def test_light_function_select(hass: HomeAssistant) -> None:
         patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
-            AsyncMock(return_value={"light_function": 1, "light_threshold": 100}),
+            AsyncMock(
+                return_value={
+                    "light_function": 1,
+                    "light_threshold": 100,
+                    "light_out_level": 0,
+                }
+            ),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.cmd_set_light_function",
+            "custom_components.ld2410.api.LD2410.cmd_set_light_config",
             AsyncMock(),
         ) as set_mock,
     ):
@@ -122,4 +128,62 @@ async def test_light_function_select(hass: HomeAssistant) -> None:
             {"entity_id": entity_id, "option": "brighter than"},
             blocking=True,
         )
-        set_mock.assert_awaited_once_with(2)
+        set_mock.assert_awaited_once_with(mode=2)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_out_level_select(hass: HomeAssistant) -> None:
+    """Test out level select entity."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(
+                return_value={
+                    "light_function": 1,
+                    "light_threshold": 100,
+                    "light_out_level": 0,
+                }
+            ),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_light_config",
+            AsyncMock(),
+        ) as set_mock,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        entity_id = "select.test_name_out_level"
+        state = hass.states.get(entity_id)
+        assert state and state.state == "default low"
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "default high"},
+            blocking=True,
+        )
+        set_mock.assert_awaited_once_with(out_level=1)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -100,7 +100,7 @@ async def test_light_function_select(hass: HomeAssistant) -> None:
         patch("custom_components.ld2410.api.LD2410.connect_and_update", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
-            AsyncMock(return_value={"light_function": True, "light_threshold": 100}),
+            AsyncMock(return_value={"light_function": 1, "light_threshold": 100}),
         ),
         patch(
             "custom_components.ld2410.api.LD2410.cmd_set_light_function",
@@ -114,12 +114,12 @@ async def test_light_function_select(hass: HomeAssistant) -> None:
 
         entity_id = "select.test_name_light_function"
         state = hass.states.get(entity_id)
-        assert state and state.state == "on"
+        assert state and state.state == "dimmer than"
 
         await hass.services.async_call(
             "select",
             "select_option",
-            {"entity_id": entity_id, "option": "off"},
+            {"entity_id": entity_id, "option": "brighter than"},
             blocking=True,
         )
-        set_mock.assert_awaited_once_with(False)
+        set_mock.assert_awaited_once_with(2)


### PR DESCRIPTION
## Summary
- add API support for light control configuration
- expose light function select and light sensitivity number entities
- update translations and tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b0ab115edc8330833f48c5cdc8f7df