### PR TITLE
Adjust tests for LD2410 initialization changes

### DIFF
--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -61,7 +61,7 @@ async def test_entities_stay_available_with_uplink_frames(hass: HomeAssistant) -
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
     ):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -53,7 +53,7 @@ async def test_auto_threshold_button(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
             AsyncMock(),
         ),
-        patch("custom_components.ld2410.api.LD2410.initial_setup", AsyncMock()),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
             AsyncMock(return_value={}),

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -1,6 +1,5 @@
 from bleak.backends.device import BLEDevice
 import pytest
-from unittest.mock import AsyncMock
 
 from custom_components.ld2410.api.devices.device import OperationError
 from custom_components.ld2410.api.devices.ld2410 import (
@@ -327,8 +326,8 @@ async def test_read_params_fail() -> None:
 
 
 @pytest.mark.asyncio
-async def test_initial_setup_reads_params() -> None:
-    """initial_setup reads parameters and stores them."""
+async def test_on_connect_reads_params() -> None:
+    """_on_connect reads parameters and stores them."""
     resp = [
         b"\x00\x00\x01\x00\x00@",
         b"\x00\x00",
@@ -348,8 +347,7 @@ async def test_initial_setup_reads_params() -> None:
         b"\x00\x00",
     ]
     dev = _TestDevice(password=None, response=resp)
-    dev._ensure_connected = AsyncMock(side_effect=dev.cmd_enable_engineering_mode)
-    await dev.initial_setup()
+    await dev._on_connect()
     assert dev.raw_commands == [
         CMD_ENABLE_CFG + "0001",
         CMD_ENABLE_ENGINEERING,

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -35,7 +35,6 @@ async def test_reconnect_after_unexpected_disconnect():
             AsyncMock(),
         ) as mock_connect,
         patch.object(device, "cmd_send_bluetooth_password", AsyncMock()) as mock_pass,
-        patch.object(device, "initial_setup", AsyncMock()),
     ):
         device._on_disconnect(None)
         await asyncio.sleep(0)
@@ -95,7 +94,7 @@ async def test_restart_connection_skips_on_connect_if_already_connected() -> Non
             "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
             AsyncMock(return_value=False),
         ) as mock_connect,
-        patch.object(device, "on_connect", AsyncMock()) as mock_on_connect,
+        patch.object(device, "_on_connect", AsyncMock()) as mock_on_connect,
     ):
         await device._restart_connection()
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -62,7 +62,7 @@ async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -157,7 +157,7 @@ async def test_light_sensitivity_number(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
             AsyncMock(),
         ),
-        patch("custom_components.ld2410.api.LD2410.initial_setup", AsyncMock()),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
             AsyncMock(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -53,7 +53,7 @@ async def test_resolution_select(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
             AsyncMock(),
         ),
-        patch("custom_components.ld2410.api.LD2410.initial_setup", AsyncMock()),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
             AsyncMock(return_value={"resolution": 0}),
@@ -113,7 +113,7 @@ async def test_light_function_select(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
             AsyncMock(),
         ),
-        patch("custom_components.ld2410.api.LD2410.initial_setup", AsyncMock()),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
             AsyncMock(
@@ -179,7 +179,7 @@ async def test_out_level_select(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
             AsyncMock(),
         ),
-        patch("custom_components.ld2410.api.LD2410.initial_setup", AsyncMock()),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
         patch(
             "custom_components.ld2410.api.devices.device.Device.get_basic_info",
             AsyncMock(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -67,7 +67,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -138,7 +138,7 @@ async def test_rssi_sensor_updates_via_connection(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -206,7 +206,7 @@ async def test_entities_created_without_initial_data(hass: HomeAssistant) -> Non
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -280,7 +280,7 @@ async def test_gate_energy_sensors(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -345,7 +345,7 @@ async def test_photo_and_out_pin_sensors(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(
@@ -403,7 +403,7 @@ async def test_frame_type_and_photo_sensors_disabled_by_default(
             AsyncMock(),
         ),
         patch(
-            "custom_components.ld2410.api.LD2410.initial_setup",
+            "custom_components.ld2410.api.LD2410._on_connect",
             AsyncMock(),
         ),
         patch(


### PR DESCRIPTION
## Summary
- update tests to patch `_on_connect` instead of removed `initial_setup`
- verify device reconnection skips `_on_connect` when already connected
- test `_on_connect` setup sequence directly

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components/ld2410`


------
https://chatgpt.com/codex/tasks/task_e_68b1e51eef348330862fabf82be2ff50