### PR TITLE
Handle non-blocking LD2410 reboot

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -379,10 +379,7 @@ class LD2410(Device):
     async def cmd_reboot(self) -> None:
         """Reboot the module."""
         await self.cmd_enable_config()
-        response = await self._send_command(CMD_REBOOT)
-        if response != b"\x00\x00":
-            raise OperationError("Failed to reboot")
-        await self.cmd_end_config()
+        await self._send_command(CMD_REBOOT, wait_for_response=False)
 
     def _parse_uplink_frame(self, data: bytes) -> Dict[str, Any] | None:
         """Parse an uplink frame.

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -463,7 +463,6 @@ async def test_set_resolution_success() -> None:
             b"\x00\x00",
             b"\x00\x00\x01\x00\x00@",
             b"\x00\x00",
-            b"\x00\x00",
         ],
     )
     await dev.cmd_set_resolution(1)
@@ -473,7 +472,6 @@ async def test_set_resolution_success() -> None:
         CMD_END_CFG,
         CMD_ENABLE_CFG + "0001",
         CMD_REBOOT,
-        CMD_END_CFG,
     ]
     assert dev.parsed_data["resolution"] == 1
 
@@ -501,25 +499,9 @@ async def test_reboot_success() -> None:
         response=[
             b"\x00\x00\x01\x00\x00@",
             b"\x00\x00",
-            b"\x00\x00",
         ],
     )
     await dev.cmd_reboot()
-    assert dev.raw_commands == [CMD_ENABLE_CFG + "0001", CMD_REBOOT, CMD_END_CFG]
-
-
-@pytest.mark.asyncio
-async def test_reboot_fail() -> None:
-    """Reboot command raises on failure."""
-    dev = _TestDevice(
-        password=None,
-        response=[
-            b"\x00\x00\x01\x00\x00@",
-            b"\x01\x00",
-        ],
-    )
-    with pytest.raises(OperationError):
-        await dev.cmd_reboot()
     assert dev.raw_commands == [CMD_ENABLE_CFG + "0001", CMD_REBOOT]
 
 


### PR DESCRIPTION
## Summary
- send reboot command without waiting for a response
- drop reboot response validation and config termination
- update command tests for new reboot behavior

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 83%

------
https://chatgpt.com/codex/tasks/task_e_68b1e94fa9708330b4463aa85e8ccc8e