### PR TITLE
Require address selection for manual LD2410 setup

### DIFF
--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -85,7 +85,6 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_adv = parsed
         self.context["title_placeholders"] = {"name": name_from_discovery(parsed)}
         return await self.async_step_password()
-        return await self.async_step_confirm()
 
     async def async_step_password(
         self, user_input: dict[str, Any] | None = None
@@ -199,16 +198,8 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
             device_adv = self._discovered_advs[user_input[CONF_ADDRESS]]
             await self._async_set_device(device_adv)
             return await self.async_step_password()
-            return await self._async_create_entry_from_discovery(user_input)
 
         self._async_discover_devices()
-        if len(self._discovered_advs) == 1:
-            # If there is only one device we can simply confirm it
-            device_adv = list(self._discovered_advs.values())[0]
-            await self._async_set_device(device_adv)
-            return await self.async_step_password()
-            return await self.async_step_confirm()
-
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -162,7 +162,13 @@ async def test_user_setup_ld2410_replaces_ignored(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "password"
+    assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "password"
 
     with (
         patch_async_setup_entry() as mock_setup_entry,
@@ -171,14 +177,14 @@ async def test_user_setup_ld2410_replaces_ignored(hass: HomeAssistant) -> None:
             AsyncMock(),
         ),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_PASSWORD: "abc123"}
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {CONF_PASSWORD: "abc123"}
         )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "HLK-LD2410_EEFF"
-    assert result["data"] == {
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "HLK-LD2410_EEFF"
+    assert result3["data"] == {
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_SENSOR_TYPE: "ld2410",
         CONF_PASSWORD: "abc123",
@@ -245,6 +251,13 @@ async def test_async_step_user_takes_precedence_over_discovery(
             context={"source": SOURCE_USER},
         )
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "password"
 
     with (
         patch_async_setup_entry() as mock_setup_entry,
@@ -253,14 +266,14 @@ async def test_async_step_user_takes_precedence_over_discovery(
             AsyncMock(),
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             user_input={CONF_PASSWORD: "abc123"},
         )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "HLK-LD2410_EEFF"
-    assert result2["data"] == {
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "HLK-LD2410_EEFF"
+    assert result3["data"] == {
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_SENSOR_TYPE: "ld2410",
         CONF_PASSWORD: "abc123",


### PR DESCRIPTION
## Summary
- prompt for Bluetooth address when adding LD2410 from the UI
- update config flow tests for new address selection step

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea4927b08330b1cf0fc3819c246f