### PR TITLE
Add buttons to save and restore gate thresholds

### DIFF
--- a/custom_components/ld2410/button.py
+++ b/custom_components/ld2410/button.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
@@ -85,14 +86,20 @@ class SaveThresholdsButton(Entity, ButtonEntity):
         """Handle the button press."""
         move = list(self.parsed_data.get("move_gate_sensitivity", []))
         still = list(self.parsed_data.get("still_gate_sensitivity", []))
-        self.hass.config_entries.async_update_entry(
-            self._entry,
-            options={
+        update_entry = self.hass.config_entries.async_update_entry
+        kwargs = {
+            "options": {
                 **self._entry.options,
                 CONF_MOVE_THRESHOLDS: move,
                 CONF_STILL_THRESHOLDS: still,
-            },
-        )
+            }
+        }
+        params = inspect.signature(update_entry).parameters
+        if "update_listeners" in params:
+            kwargs["update_listeners"] = False
+        elif "reload" in params:
+            kwargs["reload"] = False
+        update_entry(self._entry, **kwargs)
 
 
 class LoadThresholdsButton(Entity, ButtonEntity):

--- a/custom_components/ld2410/const.py
+++ b/custom_components/ld2410/const.py
@@ -31,3 +31,5 @@ DEFAULT_RETRY_COUNT = 3
 
 # Config Options
 CONF_RETRY_COUNT = "retry_count"
+CONF_MOVE_THRESHOLDS = "move_gate_sensitivity"
+CONF_STILL_THRESHOLDS = "still_gate_sensitivity"

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -30,7 +30,11 @@
     },
     "entity": {
         "binary_sensor": {"door_timeout": {"name": "Timeout"}},
-        "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "button": {
+            "auto_threshold": {"name": "Auto threshold"},
+            "save_thresholds": {"name": "Save thresholds"},
+            "load_thresholds": {"name": "Load thresholds"}
+        },
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -1,6 +1,10 @@
 {
     "entity": {
-        "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "button": {
+            "auto_threshold": {"name": "Auto threshold"},
+            "save_thresholds": {"name": "Save thresholds"},
+            "load_thresholds": {"name": "Load thresholds"}
+        },
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,13 +1,19 @@
 """Test the configuration button."""
 
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from custom_components.ld2410.const import DOMAIN
+from custom_components.ld2410.const import (
+    CONF_MOVE_THRESHOLDS,
+    CONF_RETRY_COUNT,
+    CONF_STILL_THRESHOLDS,
+    DEFAULT_RETRY_COUNT,
+    DOMAIN,
+)
 
 from . import LD2410b_SERVICE_INFO
 
@@ -96,3 +102,138 @@ async def test_auto_threshold_button(hass: HomeAssistant) -> None:
         sleep_mock.assert_has_awaits([call(10)], any_order=True)
         query_mock.assert_awaited_once()
         read_mock.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_save_thresholds_button(hass: HomeAssistant) -> None:
+    """Test saving gate thresholds to options."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    move = list(range(1, 10))
+    still = list(range(11, 20))
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(
+                return_value={
+                    "move_gate_sensitivity": move,
+                    "still_gate_sensitivity": still,
+                }
+            ),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        with patch.object(hass.config_entries, "async_update_entry") as update_mock:
+            await hass.services.async_call(
+                "button",
+                "press",
+                {"entity_id": "button.test_name_save_thresholds"},
+                blocking=True,
+            )
+
+        update_mock.assert_called_once()
+        opts = update_mock.call_args[1]["options"]
+        assert opts[CONF_MOVE_THRESHOLDS] == move
+        assert opts[CONF_STILL_THRESHOLDS] == still
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_load_thresholds_button(hass: HomeAssistant) -> None:
+    """Test loading gate thresholds from options to device."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    move = list(range(1, 10))
+    still = list(range(11, 20))
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        options={
+            CONF_RETRY_COUNT: DEFAULT_RETRY_COUNT,
+            CONF_MOVE_THRESHOLDS: move,
+            CONF_STILL_THRESHOLDS: still,
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value={}),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_gate_sensitivity",
+            AsyncMock(),
+        ) as set_mock,
+        patch(
+            "custom_components.ld2410.api.devices.device.Device._fire_callbacks",
+            Mock(),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": "button.test_name_load_thresholds"},
+            blocking=True,
+        )
+
+        expected = [call(i, move[i], still[i]) for i in range(9)]
+        set_mock.assert_has_awaits(expected)


### PR DESCRIPTION
## Summary
- add config buttons to persist and restore gate thresholds
- expose button labels and translations
- test save and load threshold operations

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`

## Coverage
84%

------
https://chatgpt.com/codex/tasks/task_e_68b1f1bb16ac8330ab67b8d77e2e54bc