### PR TITLE
Add sensitivity save/load controls

### DIFF
--- a/custom_components/ld2410/const.py
+++ b/custom_components/ld2410/const.py
@@ -31,3 +31,5 @@ DEFAULT_RETRY_COUNT = 3
 
 # Config Options
 CONF_RETRY_COUNT = "retry_count"
+CONF_SAVED_MOVE_SENSITIVITY = "saved_move_gate_sensitivity"
+CONF_SAVED_STILL_SENSITIVITY = "saved_still_gate_sensitivity"

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -30,7 +30,11 @@
     },
     "entity": {
         "binary_sensor": {"door_timeout": {"name": "Timeout"}},
-        "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "button": {
+            "auto_sensitivities": {"name": "Auto sensitivities"},
+            "save_sensitivities": {"name": "Save sensitivities"},
+            "load_sensitivities": {"name": "Load sensitivities"}
+        },
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},
@@ -42,7 +46,7 @@
             "wifi_signal": {"name": "Wi-Fi signal"},
             "light_level": {"name": "Light level"},
             "firmware_version": {"name": "Firmware version"},
-            "firmware_build_date": {"name": "Firmware build date"},
+            "firmware_build_date": {"name": "Firmware build date"}
         },
     },
     "exceptions": {
@@ -55,6 +59,6 @@
         "advertising_state_error": {"message": "{address} is not advertising state"},
         "device_not_found_error": {
             "message": "Could not find {sensor_type} with address {address}"
-        },
-    },
+        }
+    }
 }

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -1,6 +1,10 @@
 {
     "entity": {
-        "button": {"auto_threshold": {"name": "Auto threshold"}},
+        "button": {
+            "auto_sensitivities": {"name": "Auto sensitivities"},
+            "save_sensitivities": {"name": "Save sensitivities"},
+            "load_sensitivities": {"name": "Load sensitivities"}
+        },
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -7,7 +7,11 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from custom_components.ld2410.const import DOMAIN
+from custom_components.ld2410.const import (
+    CONF_SAVED_MOVE_SENSITIVITY,
+    CONF_SAVED_STILL_SENSITIVITY,
+    DOMAIN,
+)
 
 from . import LD2410b_SERVICE_INFO
 
@@ -23,8 +27,8 @@ except ImportError:  # Home Assistant <2023.9
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_auto_threshold_button(hass: HomeAssistant) -> None:
-    """Test pressing the button starts auto threshold detection."""
+async def test_auto_sensitivities_button(hass: HomeAssistant) -> None:
+    """Test pressing the button starts auto sensitivity detection."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
 
@@ -83,12 +87,12 @@ async def test_auto_threshold_button(hass: HomeAssistant) -> None:
         inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
         await hass.async_block_till_done()
 
-        assert hass.states.get("button.test_name_auto_threshold") is not None
+        assert hass.states.get("button.test_name_auto_sensitivities") is not None
 
         await hass.services.async_call(
             "button",
             "press",
-            {"entity_id": "button.test_name_auto_threshold"},
+            {"entity_id": "button.test_name_auto_sensitivities"},
             blocking=True,
         )
 
@@ -96,3 +100,95 @@ async def test_auto_threshold_button(hass: HomeAssistant) -> None:
         sleep_mock.assert_has_awaits([call(10)], any_order=True)
         query_mock.assert_awaited_once()
         read_mock.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
+    """Test saving and loading sensitivities."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+    mock_parsed = {
+        "move_gate_sensitivity": list(range(9)),
+        "still_gate_sensitivity": list(range(9, 18)),
+    }
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value=mock_parsed),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("button.test_name_save_sensitivities") is not None
+    assert hass.states.get("button.test_name_load_sensitivities") is not None
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": "button.test_name_save_sensitivities"},
+            blocking=True,
+        )
+
+    assert (
+        entry.options[CONF_SAVED_MOVE_SENSITIVITY]
+        == mock_parsed["move_gate_sensitivity"]
+    )
+    assert (
+        entry.options[CONF_SAVED_STILL_SENSITIVITY]
+        == mock_parsed["still_gate_sensitivity"]
+    )
+
+    new_move = [50] * 9
+    new_still = [60] * 9
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()):
+        hass.config_entries.async_update_entry(
+            entry,
+            options={
+                **entry.options,
+                CONF_SAVED_MOVE_SENSITIVITY: new_move,
+                CONF_SAVED_STILL_SENSITIVITY: new_still,
+            },
+        )
+
+    with patch(
+        "custom_components.ld2410.api.LD2410.cmd_set_gate_sensitivity",
+        AsyncMock(),
+    ) as set_mock:
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": "button.test_name_load_sensitivities"},
+            blocking=True,
+        )
+
+    set_mock.assert_has_awaits([call(g, 50, 60) for g in range(9)], any_order=False)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -116,7 +116,7 @@ async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
             await hass.services.async_call(
                 "button",
                 "press",
-                {"entity_id": "button.test_name_auto_threshold"},
+                {"entity_id": "button.test_name_auto_sensitivities"},
                 blocking=True,
             )
             await hass.async_block_till_done()


### PR DESCRIPTION
## Summary
- rename auto threshold button to auto sensitivities
- add buttons to save and load gate sensitivities
- update translations and tests

## Testing
- `ruff check . --fix`
- `ruff format custom_components/ld2410/button.py custom_components/ld2410/const.py custom_components/ld2410/strings.json custom_components/ld2410/translations/en.json tests/test_button.py tests/test_number.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2080c47188330a5197446287777b5