### PR TITLE
Cancel stale restart tasks on LD2410 unload

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -151,6 +151,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     previous_auto_reconnect = device._auto_reconnect
     device._auto_reconnect = False
     device._cancel_disconnect_timer()
+    if device._restart_connection_task:
+        device._restart_connection_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await device._restart_connection_task
+        device._restart_connection_task = None
     if device._timed_disconnect_task:
         device._timed_disconnect_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):


### PR DESCRIPTION
## Summary
- track `_restart_connection_task` and cancel it when unloading an entry
- ensure `_restart_connection` clears its task reference when finished
- add regression test for reconnect task cancellation

## Testing
- `ruff check custom_components/ld2410/__init__.py custom_components/ld2410/api/devices/device.py tests/test_device_disconnect.py --fix`
- `ruff format custom_components/ld2410/__init__.py custom_components/ld2410/api/devices/device.py tests/test_device_disconnect.py`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
84%


------
https://chatgpt.com/codex/tasks/task_e_68b234413f748330b8a6a58fcdbaf5be