### PR TITLE
Add Bluetooth password change support

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -39,6 +39,7 @@ PLATFORMS_BY_TYPE = {
         Platform.BUTTON,
         Platform.NUMBER,
         Platform.SELECT,
+        Platform.TEXT,
     ],
 }
 CLASS_BY_DEVICE = {SupportedModels.LD2410.value: api.LD2410}

--- a/custom_components/ld2410/strings.json
+++ b/custom_components/ld2410/strings.json
@@ -6,17 +6,17 @@
                 "data": {"address": "MAC address"},
                 "data_description": {
                     "address": "The Bluetooth MAC address of your device"
-                },
+                }
             },
-            "confirm": {"description": "Do you want to set up {name}?"},
+            "confirm": {"description": "Do you want to set up {name}?"}
         },
         "error": {},
         "abort": {
             "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
             "no_devices_found": "No supported devices found in range; If the device is in range, ensure the scanner has active scanning enabled, as these devices cannot be discovered with passive scans. Active scans can be disabled once the device is configured. If you need clarification on whether the device is in-range, download the diagnostics for the integration that provides your Bluetooth adapter or proxy and check if the MAC address of the device is present.",
             "unknown": "[%key:common::config_flow::error::unknown%]",
-            "unsupported_type": "Unsupported device type.",
-        },
+            "unsupported_type": "Unsupported device type."
+        }
     },
     "options": {
         "step": {
@@ -24,7 +24,7 @@
                 "data": {"retry_count": "Retry count"},
                 "data_description": {
                     "retry_count": "How many times to retry sending commands to your devices"
-                },
+                }
             }
         }
     },
@@ -33,8 +33,10 @@
         "button": {
             "auto_sensitivities": {"name": "Auto sensitivities"},
             "save_sensitivities": {"name": "Save sensitivities"},
-            "load_sensitivities": {"name": "Load sensitivities"}
+            "load_sensitivities": {"name": "Load sensitivities"},
+            "change_password": {"name": "Change password"}
         },
+        "text": {"new_password": {"name": "New password"}},
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},
@@ -47,7 +49,7 @@
             "light_level": {"name": "Light level"},
             "firmware_version": {"name": "Firmware version"},
             "firmware_build_date": {"name": "Firmware build date"}
-        },
+        }
     },
     "exceptions": {
         "operation_error": {

--- a/custom_components/ld2410/text.py
+++ b/custom_components/ld2410/text.py
@@ -1,0 +1,54 @@
+"""Text entity for changing bluetooth password."""
+
+from __future__ import annotations
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+try:
+    from homeassistant.helpers.entity_platform import (
+        AddConfigEntryEntitiesCallback,
+    )
+except ImportError:  # Home Assistant <2024.6
+    from homeassistant.helpers.entity_platform import (
+        AddEntitiesCallback as AddConfigEntryEntitiesCallback,
+    )
+
+from .coordinator import ConfigEntryType, DataCoordinator
+from .entity import Entity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntryType,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up text entities based on a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities([NewPasswordText(coordinator)])
+
+
+class NewPasswordText(Entity, TextEntity):
+    """Text field for providing a new bluetooth password."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "new_password"
+    _attr_mode = TextMode.TEXT
+    _attr_pattern = r"^[ -~]*$"
+
+    def __init__(self, coordinator: DataCoordinator) -> None:
+        """Initialize the text entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}-new_password"
+        coordinator.new_password = ""
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current value."""
+        return getattr(self.coordinator, "new_password", "")
+
+    async def async_set_value(self, value: str) -> None:
+        """Set the text value."""
+        self.coordinator.new_password = value
+        self.async_write_ha_state()

--- a/custom_components/ld2410/translations/en.json
+++ b/custom_components/ld2410/translations/en.json
@@ -3,8 +3,10 @@
         "button": {
             "auto_sensitivities": {"name": "Auto sensitivities"},
             "save_sensitivities": {"name": "Save sensitivities"},
-            "load_sensitivities": {"name": "Load sensitivities"}
+            "load_sensitivities": {"name": "Load sensitivities"},
+            "change_password": {"name": "Change password"}
         },
+        "text": {"new_password": {"name": "New password"}},
         "select": {
             "distance_resolution": {"name": "Distance resolution"},
             "light_function": {"name": "Light function"},


### PR DESCRIPTION
## Summary
- add a text field and button to change the device's Bluetooth password
- persist the new password and reboot after a successful change
- cover password change workflow with tests and translations

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc3529748330bb2b0f9f297fb7be