### PR TITLE
Prevent reconnection loop on password validation

### DIFF
--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -97,10 +97,14 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
                 device=self._discovered_adv.device,
                 password=user_input[CONF_PASSWORD],
             )
+            previous_auto_reconnect = device._auto_reconnect
+            device._auto_reconnect = False
             try:
                 await device.cmd_send_bluetooth_password()
             except OperationError:
                 errors["base"] = "wrong_password"
+            finally:
+                device._auto_reconnect = previous_auto_reconnect
             if not errors:
                 return await self._async_create_entry_from_discovery(user_input)
 

--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -103,6 +103,7 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
                 await device.cmd_send_bluetooth_password()
             except OperationError:
                 errors["base"] = "wrong_password"
+                await device.async_disconnect()
             finally:
                 device._auto_reconnect = previous_auto_reconnect
             if not errors:


### PR DESCRIPTION
## Summary
- disable auto reconnect while validating password during config flow
- add regression test to ensure auto reconnect is restored after check

## Testing
- `ruff check custom_components/ld2410/config_flow.py tests/test_config_flow.py --fix`
- `ruff format custom_components/ld2410/config_flow.py tests/test_config_flow.py`
- `pytest`
- `pytest --cov` (84% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68b37c378ed08330b2c7d26ef35ab389