### PR TITLE
Add helper for ephemeral notifications

### DIFF
--- a/custom_components/ld2410/helpers.py
+++ b/custom_components/ld2410/helpers.py
@@ -1,0 +1,32 @@
+"""Helper utilities for the LD2410 integration."""
+
+from homeassistant.components import persistent_notification
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_call_later
+
+
+async def _async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
+    """Dismiss a persistent notification."""
+    persistent_notification.async_dismiss(hass, notification_id)
+
+
+def async_ephemeral_notification(
+    hass: HomeAssistant,
+    message: str,
+    *,
+    title: str,
+    notification_id: str,
+    duration: float = 10,
+) -> None:
+    """Create a notification that dismisses itself after ``duration`` seconds."""
+    persistent_notification.async_create(
+        hass,
+        message,
+        title=title,
+        notification_id=notification_id,
+    )
+    async_call_later(
+        hass,
+        duration,
+        lambda _: hass.async_create_task(_async_dismiss(hass, notification_id)),
+    )

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -84,7 +84,7 @@ async def test_auto_sensitivities_button(hass: HomeAssistant) -> None:
         patch(
             "custom_components.ld2410.button.asyncio.sleep", AsyncMock()
         ) as sleep_mock,
-        patch("custom_components.ld2410.button.async_call_later") as call_later_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -113,6 +113,7 @@ async def test_auto_sensitivities_button(hass: HomeAssistant) -> None:
             "Please keep the room empty for 10 seconds while calibration is in progress"
         )
         dismiss(None)
+        await hass.async_block_till_done()
         notifications = persistent_notification._async_get_or_create_notifications(hass)
         assert "ld2410_auto_sensitivities" not in notifications
 
@@ -169,7 +170,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
 
     with (
         patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock,
-        patch("custom_components.ld2410.button.async_call_later") as call_later_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
     ):
         await hass.services.async_call(
             "button",
@@ -197,6 +198,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
         "Sensitivities successfully saved to configurations"
     )
     dismiss(None)
+    await hass.async_block_till_done()
     notifications = persistent_notification._async_get_or_create_notifications(hass)
     assert "ld2410_save_sensitivities" not in notifications
 
@@ -217,7 +219,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_set_gate_sensitivity",
             AsyncMock(),
         ) as set_mock,
-        patch("custom_components.ld2410.button.async_call_later") as call_later_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
     ):
         await hass.services.async_call(
             "button",
@@ -236,6 +238,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
         "Successfully loaded previously saved gate sensitivities into the device"
     )
     dismiss(None)
+    await hass.async_block_till_done()
     notifications = persistent_notification._async_get_or_create_notifications(hass)
     assert "ld2410_load_sensitivities" not in notifications
 
@@ -285,7 +288,7 @@ async def test_change_password_button(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_reboot",
             AsyncMock(),
         ) as reboot_mock,
-        patch("custom_components.ld2410.button.async_call_later") as call_later_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -357,7 +360,7 @@ async def test_change_password_button_invalid(hass: HomeAssistant) -> None:
             "custom_components.ld2410.api.LD2410.cmd_reboot",
             AsyncMock(),
         ) as reboot_mock,
-        patch("custom_components.ld2410.button.async_call_later") as call_later_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -386,6 +389,7 @@ async def test_change_password_button_invalid(hass: HomeAssistant) -> None:
         )
         dismiss = call_later_mock.call_args[0][2]
         dismiss(None)
+        await hass.async_block_till_done()
         notifications = persistent_notification._async_get_or_create_notifications(hass)
         assert "ld2410_change_password" not in notifications
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -113,7 +113,7 @@ async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
             ),
             patch("custom_components.ld2410.button.asyncio.sleep", AsyncMock()),
             patch(
-                "custom_components.ld2410.button.async_call_later"
+                "custom_components.ld2410.helpers.async_call_later"
             ) as call_later_mock,
         ):
             await hass.services.async_call(
@@ -126,6 +126,7 @@ async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
             call_later_mock.assert_called_once()
             dismiss = call_later_mock.call_args[0][2]
             dismiss(None)
+            await hass.async_block_till_done()
 
         assert hass.states.get("number.test_name_mg0_sensitivity").state == "90"
         assert hass.states.get("number.test_name_sg0_sensitivity").state == "80"


### PR DESCRIPTION
## Summary
- centralize auto-dismissing persistent notifications in `async_ephemeral_notification`
- use helper for LD2410 button notifications
- update tests to patch new helper

## Testing
- `ruff check . --fix`
- `ruff format custom_components/ld2410/button.py custom_components/ld2410/helpers.py tests/test_button.py tests/test_number.py`
- `pytest`
- `pytest --maxfail=1 --disable-warnings --cov`

## Coverage
84%

------
https://chatgpt.com/codex/tasks/task_e_68b3a6490d0083308289c469f8a88b3d