### PR TITLE
Fix thread-safe notification dismissal

### DIFF
--- a/custom_components/ld2410/helpers.py
+++ b/custom_components/ld2410/helpers.py
@@ -1,5 +1,7 @@
 """Helper utilities for the LD2410 integration."""
 
+import asyncio
+
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_call_later
@@ -25,8 +27,17 @@ def async_ephemeral_notification(
         title=title,
         notification_id=notification_id,
     )
-    async_call_later(
-        hass,
-        duration,
-        lambda _: hass.async_create_task(_async_dismiss(hass, notification_id)),
-    )
+
+    def _handle_dismiss(_: float) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is hass.loop:
+            hass.async_create_task(_async_dismiss(hass, notification_id))
+        else:
+            hass.loop.call_soon_threadsafe(
+                hass.async_create_task, _async_dismiss(hass, notification_id)
+            )
+
+    async_call_later(hass, duration, _handle_dismiss)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from custom_components.ld2410.helpers import async_ephemeral_notification
+
+
+async def test_async_ephemeral_notification_dismisses(hass):
+    """Notification is dismissed without thread-safety error."""
+    with (
+        patch(
+            "custom_components.ld2410.helpers.persistent_notification.async_create"
+        ) as mock_create,
+        patch(
+            "custom_components.ld2410.helpers.persistent_notification.async_dismiss"
+        ) as mock_dismiss,
+    ):
+        async_ephemeral_notification(
+            hass, "message", title="title", notification_id="notif", duration=0
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    mock_create.assert_called_once()
+    mock_dismiss.assert_called_once_with(hass, "notif")


### PR DESCRIPTION
## Summary
- ensure ld2410 notifications dismiss safely from executor threads
- add regression test for ephemeral notifications

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- `84%`

------
https://chatgpt.com/codex/tasks/task_e_68b48858beec8330915306dc402079c4