### PR TITLE
Close stale BLE connections on unload and run notification dismissal on loop

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -164,6 +164,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await device._timed_disconnect_task
         device._timed_disconnect_task = None
     await device.async_disconnect()
+    await api.close_stale_connections_by_address(entry.data[CONF_ADDRESS])
     return await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS_BY_TYPE[sensor_type]
     )

--- a/custom_components/ld2410/helpers.py
+++ b/custom_components/ld2410/helpers.py
@@ -1,7 +1,5 @@
 """Helper utilities for the LD2410 integration."""
 
-import asyncio
-
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_call_later
@@ -28,16 +26,7 @@ def async_ephemeral_notification(
         notification_id=notification_id,
     )
 
-    def _handle_dismiss(_: float) -> None:
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        if loop is hass.loop:
-            hass.async_create_task(_async_dismiss(hass, notification_id))
-        else:
-            hass.loop.call_soon_threadsafe(
-                hass.async_create_task, _async_dismiss(hass, notification_id)
-            )
+    async def _dismiss_cb(_: float) -> None:
+        await _async_dismiss(hass, notification_id)
 
-    async_call_later(hass, duration, _handle_dismiss)
+    async_call_later(hass, duration, _dismiss_cb)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -112,7 +112,7 @@ async def test_auto_sensitivities_button(hass: HomeAssistant) -> None:
         assert notifications["ld2410_auto_sensitivities"]["message"] == (
             "Please keep the room empty for 10 seconds while calibration is in progress"
         )
-        dismiss(None)
+        await dismiss(None)
         await hass.async_block_till_done()
         notifications = persistent_notification._async_get_or_create_notifications(hass)
         assert "ld2410_auto_sensitivities" not in notifications
@@ -197,7 +197,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
     assert notifications["ld2410_save_sensitivities"]["message"] == (
         "Sensitivities successfully saved to configurations"
     )
-    dismiss(None)
+    await dismiss(None)
     await hass.async_block_till_done()
     notifications = persistent_notification._async_get_or_create_notifications(hass)
     assert "ld2410_save_sensitivities" not in notifications
@@ -237,7 +237,7 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
     assert notifications["ld2410_load_sensitivities"]["message"] == (
         "Successfully loaded previously saved gate sensitivities into the device"
     )
-    dismiss(None)
+    await dismiss(None)
     await hass.async_block_till_done()
     notifications = persistent_notification._async_get_or_create_notifications(hass)
     assert "ld2410_load_sensitivities" not in notifications
@@ -388,7 +388,7 @@ async def test_change_password_button_invalid(hass: HomeAssistant) -> None:
             == "Password must be exactly 6 characters long"
         )
         dismiss = call_later_mock.call_args[0][2]
-        dismiss(None)
+        await dismiss(None)
         await hass.async_block_till_done()
         notifications = persistent_notification._async_get_or_create_notifications(hass)
         assert "ld2410_change_password" not in notifications

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -125,7 +125,7 @@ async def test_gate_sensitivity_numbers(hass: HomeAssistant) -> None:
             await hass.async_block_till_done()
             call_later_mock.assert_called_once()
             dismiss = call_later_mock.call_args[0][2]
-            dismiss(None)
+            await dismiss(None)
             await hass.async_block_till_done()
 
         assert hass.states.get("number.test_name_mg0_sensitivity").state == "90"


### PR DESCRIPTION
## Summary
- ensure stale BLE clients are closed when unloading an entry
- schedule ephemeral notification dismissal on the event loop

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components/ld2410 --cov-report term`

## Coverage
- `84%`

------
https://chatgpt.com/codex/tasks/task_e_68b48ae3671483308c6529464d808b83