### PR TITLE
Handle device initialization within ensure_connected

### DIFF
--- a/custom_components/ld2410/__init__.py
+++ b/custom_components/ld2410/__init__.py
@@ -101,8 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool
         return False
 
     if entry.data.get(CONF_PASSWORD):
-        if await device._ensure_connected():
-            await device._on_connect()
+        await device._ensure_connected()
 
     data_coordinator = entry.runtime_data = DataCoordinator(
         hass,

--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -276,6 +276,7 @@ class BaseDevice:
             retry = self._retry_count
         command = self._modify_command(raw_command)
         max_attempts = retry + 1
+        await self._ensure_connected()
         if self._operation_lock.locked():
             _LOGGER.debug(
                 "%s: Operation already in progress, waiting for it to complete; RSSI: %s",
@@ -541,7 +542,6 @@ class BaseDevice:
         self, raw_command: str, command: bytes, wait_for_response: bool
     ) -> bytes | None:
         """Send command to device and optionally read response."""
-        await self._ensure_connected()
         try:
             return await self._execute_command_locked(
                 raw_command, command, wait_for_response

--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -337,7 +337,7 @@ class BaseDevice:
         return bool(self._client and self._client.is_connected)
 
     async def _ensure_connected(self) -> bool:
-        """Ensure connection to device is established.
+        """Ensure connection to device is established and initialized.
 
         Returns True if a new connection was made.
         """
@@ -399,6 +399,7 @@ class BaseDevice:
             )
             self._reset_disconnect_timer()
             await self._start_notify()
+            await self._on_connect()
             return True
 
     def _reset_disconnect_timer(self):
@@ -489,9 +490,7 @@ class BaseDevice:
             return
         try:
             _LOGGER.debug("%s: Reconnecting...", self.name)
-            connected = await self._ensure_connected()
-            if connected:
-                await self._on_connect()
+            await self._ensure_connected()
         except asyncio.CancelledError:
             raise  # do not reschedule when cancelled
         except Exception as ex:  # pragma: no cover - best effort

--- a/custom_components/ld2410/config_flow.py
+++ b/custom_components/ld2410/config_flow.py
@@ -102,9 +102,8 @@ class LD2410ConfigFlow(ConfigFlow, domain=DOMAIN):
                 await device.cmd_send_bluetooth_password()
             except OperationError:
                 errors["base"] = "wrong_password"
-                await device.async_disconnect()
             finally:
-                device._should_reconnect = device._auto_reconnect
+                await device.async_disconnect()
             if not errors:
                 return await self._async_create_entry_from_discovery(user_input)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -51,6 +51,10 @@ async def test_bluetooth_discovery_requires_password(hass: HomeAssistant) -> Non
             "custom_components.ld2410.config_flow.LD2410.cmd_send_bluetooth_password",
             AsyncMock(),
         ),
+        patch(
+            "custom_components.ld2410.config_flow.LD2410.async_disconnect",
+            AsyncMock(),
+        ) as mock_disconnect,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -67,6 +71,7 @@ async def test_bluetooth_discovery_requires_password(hass: HomeAssistant) -> Non
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
+    mock_disconnect.assert_awaited_once()
 
 
 async def test_bluetooth_wrong_password_allows_retry(hass: HomeAssistant) -> None:
@@ -94,7 +99,7 @@ async def test_bluetooth_wrong_password_allows_retry(hass: HomeAssistant) -> Non
             result["flow_id"],
             {CONF_PASSWORD: "bad"},
         )
-    assert device._should_reconnect is True
+    assert device._should_reconnect is False
     device.async_disconnect.assert_awaited_once()
     assert result2["type"] is FlowResultType.FORM
     assert result2["step_id"] == "password"

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -82,15 +82,21 @@ async def test_wait_for_response_defaults_to_class_setting() -> None:
         device=BLEDevice(address="AA:BB", name="test", details=None, rssi=-60),
         password=None,
     )
-    with patch.object(
-        dev, "_send_command_locked_with_retry", AsyncMock(return_value=None)
-    ) as mock_send:
+    with (
+        patch.object(dev, "_ensure_connected", AsyncMock()),
+        patch.object(
+            dev, "_send_command_locked_with_retry", AsyncMock(return_value=None)
+        ) as mock_send,
+    ):
         await dev._send_command("FF000100")
         assert mock_send.await_args.args[4] is False
 
-    with patch.object(
-        dev, "_send_command_locked_with_retry", AsyncMock(return_value=None)
-    ) as mock_send:
+    with (
+        patch.object(dev, "_ensure_connected", AsyncMock()),
+        patch.object(
+            dev, "_send_command_locked_with_retry", AsyncMock(return_value=None)
+        ) as mock_send,
+    ):
         await dev._send_command("FF000100", wait_for_response=True)
         assert mock_send.await_args.args[4] is True
 
@@ -98,9 +104,12 @@ async def test_wait_for_response_defaults_to_class_setting() -> None:
         device=BLEDevice(address="AA:BB", name="test", details=None, rssi=-60),
         password=None,
     )
-    with patch.object(
-        dev_true, "_send_command_locked_with_retry", AsyncMock(return_value=None)
-    ) as mock_send:
+    with (
+        patch.object(dev_true, "_ensure_connected", AsyncMock()),
+        patch.object(
+            dev_true, "_send_command_locked_with_retry", AsyncMock(return_value=None)
+        ) as mock_send,
+    ):
         await dev_true._send_command("FF000100")
         assert mock_send.await_args.args[4] is True
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -127,6 +127,10 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
+    async def mock_ensure_connected(self):
+        await self._on_connect()
+        return True
+
     with (
         patch("custom_components.ld2410.api.close_stale_connections_by_address"),
         patch(
@@ -135,7 +139,7 @@ async def test_send_password_on_setup(hass: HomeAssistant) -> None:
         ) as mock_send,
         patch(
             "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
-            AsyncMock(),
+            mock_ensure_connected,
         ),
         patch(
             "custom_components.ld2410.api.LD2410.cmd_enable_config",


### PR DESCRIPTION
## Summary
- avoid duplicate `_on_connect` calls during setup
- initialize device within `_ensure_connected`
- update reconnection logic and tests
- disconnect temporary device during password validation

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components/ld2410 --cov=tests`

## Test Coverage
- 91%

------
https://chatgpt.com/codex/tasks/task_e_68b49fc840f083309d55d5eb07a6185d