### PR TITLE
warn when loading sensitivities without saved data

### DIFF
--- a/custom_components/ld2410/button.py
+++ b/custom_components/ld2410/button.py
@@ -145,18 +145,25 @@ class LoadSensitivitiesButton(Entity, ButtonEntity):
         """Handle the button press."""
         move = self._entry.options.get(CONF_SAVED_MOVE_SENSITIVITY) or []
         still = self._entry.options.get(CONF_SAVED_STILL_SENSITIVITY) or []
-        for gate, (m, s) in enumerate(zip(move, still)):
-            await self._device.cmd_set_gate_sensitivity(gate, m, s)
-        if move and still:
-            self._device._fire_callbacks()
-            LOGGER.info("Loaded saved gate sensitivities into device")
-            notification_id = "ld2410_load_sensitivities"
+        notification_id = "ld2410_load_sensitivities"
+        if not move or not still:
             async_ephemeral_notification(
                 self.hass,
-                "Successfully loaded previously saved gate sensitivities into the device",
+                "No saved gate sensitivities found",
                 title="LD2410",
                 notification_id=notification_id,
             )
+            return
+        for gate, (m, s) in enumerate(zip(move, still)):
+            await self._device.cmd_set_gate_sensitivity(gate, m, s)
+        self._device._fire_callbacks()
+        LOGGER.info("Loaded saved gate sensitivities into device")
+        async_ephemeral_notification(
+            self.hass,
+            "Successfully loaded previously saved gate sensitivities into the device",
+            title="LD2410",
+            notification_id=notification_id,
+        )
 
 
 class ChangePasswordButton(Entity, ButtonEntity):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -244,6 +244,86 @@ async def test_save_and_load_sensitivities_buttons(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_load_sensitivities_button_without_saved_data(
+    hass: HomeAssistant,
+) -> None:
+    """Test loading sensitivities when none have been saved."""
+    await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "persistent_notification", {})
+    inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": "AA:BB:CC:DD:EE:FF",
+            "name": "test-name",
+            "password": "test-password",
+            "sensor_type": "ld2410",
+        },
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+    mock_parsed = {
+        "move_gate_sensitivity": list(range(9)),
+        "still_gate_sensitivity": list(range(9, 18)),
+    }
+    with (
+        patch("custom_components.ld2410.api.close_stale_connections_by_address"),
+        patch(
+            "custom_components.ld2410.api.devices.device.BaseDevice._ensure_connected",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_send_bluetooth_password",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_enable_engineering_mode",
+            AsyncMock(),
+        ),
+        patch("custom_components.ld2410.api.LD2410._on_connect", AsyncMock()),
+        patch(
+            "custom_components.ld2410.api.devices.device.Device.get_basic_info",
+            AsyncMock(return_value=mock_parsed),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        inject_bluetooth_service_info(hass, LD2410b_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("button.test_name_load_sensitivities") is not None
+
+    with (
+        patch(
+            "custom_components.ld2410.api.LD2410.cmd_set_gate_sensitivity",
+            AsyncMock(),
+        ) as set_mock,
+        patch("custom_components.ld2410.helpers.async_call_later") as call_later_mock,
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": "button.test_name_load_sensitivities"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    set_mock.assert_not_awaited()
+    call_later_mock.assert_called_once()
+    assert call_later_mock.call_args_list[0][0][1] == 10
+    dismiss = call_later_mock.call_args_list[0][0][2]
+    notifications = persistent_notification._async_get_or_create_notifications(hass)
+    assert notifications["ld2410_load_sensitivities"]["message"] == (
+        "No saved gate sensitivities found"
+    )
+    dismiss(None)
+    await hass.async_block_till_done()
+    notifications = persistent_notification._async_get_or_create_notifications(hass)
+    assert "ld2410_load_sensitivities" not in notifications
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_change_password_button(hass: HomeAssistant) -> None:
     """Test changing the bluetooth password."""
     await async_setup_component(hass, DOMAIN, {})


### PR DESCRIPTION
## Summary
- warn when loading sensitivities when no saved values are available
- add unit test for loading without saved sensitivities

## Reasoning
Users received no feedback when attempting to load sensitivities before any values were saved. Providing an ephemeral warning clarifies the action and avoids confusion.

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=custom_components.ld2410`

Test coverage: 85%


------
https://chatgpt.com/codex/tasks/task_e_68b4c6b5154c8330b2e701858b047113