### PR TITLE
Mark LD2410 entities unavailable during reconnect

### DIFF
--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -153,6 +153,7 @@ class BaseDevice:
         if self._should_reconnect:
             task = self.loop.create_task(self._restart_connection())
             self._restart_connection_tasks.append(task)
+        self._fire_callbacks()
 
     def _resolve_characteristics(self, services: BleakGATTServiceCollection) -> None:
         """Resolve GATT characteristics used for I/O.
@@ -336,6 +337,11 @@ class BaseDevice:
     def is_connected(self) -> bool:
         """Return if the BLE client is connected."""
         return bool(self._client and self._client.is_connected)
+
+    @property
+    def is_reconnecting(self) -> bool:
+        """Return if the device is attempting to reconnect."""
+        return not self.is_connected and bool(self._restart_connection_tasks)
 
     async def _ensure_connected(self) -> bool:
         """Ensure connection to device is established and initialized.
@@ -763,6 +769,7 @@ class BaseDevice:
             return False
         time_since_last_full_update = time.monotonic() - self._last_full_update
         return not time_since_last_full_update < PASSIVE_POLL_INTERVAL
+
 
 class Device(BaseDevice):
     """Representation of a device."""

--- a/custom_components/ld2410/entity.py
+++ b/custom_components/ld2410/entity.py
@@ -66,7 +66,10 @@ class Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.device.is_connected or super().available
+        device = self.coordinator.device
+        if device.is_reconnecting:
+            return False
+        return device.is_connected or super().available
 
     @callback
     def _async_update_attrs(self) -> None:


### PR DESCRIPTION
## Summary
- mark entities as unavailable while the device is reconnecting
- expose reconnecting state on the device and notify entities on disconnect
- add regression test for availability during reconnect

## Testing
- `ruff check . --fix`
- `ruff format custom_components/ld2410/api/devices/device.py custom_components/ld2410/entity.py tests/test_availability.py`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 85%


------
https://chatgpt.com/codex/tasks/task_e_68b4c7a6b0048330b7ce278f83b4d9ce