### PR TITLE
Log negotiation completion on connect

### DIFF
--- a/custom_components/ld2410/api/devices/ld2410.py
+++ b/custom_components/ld2410/api/devices/ld2410.py
@@ -96,6 +96,10 @@ class LD2410(Device):
                 "resolution": res,
             }
         )
+        _LOGGER.info(
+            "%s: Negotiation complete, start receiving uplink frames…",
+            self.name,
+        )
 
     def _modify_command(self, raw_command: str) -> bytes:
         command_word = raw_command[:4]


### PR DESCRIPTION
## Summary
- log when device negotiation has finished so uplink frames can be received

## Testing
- `ruff check custom_components/ld2410/api/devices/ld2410.py --fix`
- `ruff format custom_components/ld2410/api/devices/ld2410.py`
- `pytest --cov`

## Test Coverage
- 85%


------
https://chatgpt.com/codex/tasks/task_e_68b6333404d08330b678324dc810d2ae