### PR TITLE
Use asyncio.TimeoutError in device command execution

### DIFF
--- a/custom_components/ld2410/api/devices/device.py
+++ b/custom_components/ld2410/api/devices/device.py
@@ -619,7 +619,7 @@ class BaseDevice:
         timeout_expired = False
         try:
             notify_msg_raw = await self._notify_future
-        except TimeoutError:
+        except asyncio.TimeoutError:
             timeout_expired = True
             raise
         finally:


### PR DESCRIPTION
## Summary
- Catch `asyncio.TimeoutError` in `_execute_command_locked` to match `_handle_timeout`

## Reasoning
- Aligns with the exception raised by `_handle_timeout`, ensuring command timeouts are handled consistently and cleanup logic runs reliably

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest` and `pytest --cov` (85% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68b63dd2e24c8330bfb9f9eff78799f7