### PR TITLE
Log advertisement data before ready event

### DIFF
--- a/custom_components/ld2410/coordinator.py
+++ b/custom_components/ld2410/coordinator.py
@@ -107,6 +107,7 @@ class DataCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
             )
         ):
             return
+        _LOGGER.debug("%s: Advertisement data: %s", self.ble_device.address, adv.data)
         if "modelName" in adv.data:
             self._ready_event.set()
         _LOGGER.debug("%s: Device data: %s", self.ble_device.address, self.device.data)


### PR DESCRIPTION
## Summary
- log BLE advertisement data before checking for modelName

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov`

## Coverage
- `85%`

------
https://chatgpt.com/codex/tasks/task_e_68bb3a1cb964833086a9bb0c457eedd1