### PR TITLE
Avoid redundant LD2410 entity updates

### DIFF
--- a/custom_components/ld2410/entity.py
+++ b/custom_components/ld2410/entity.py
@@ -78,7 +78,22 @@ class Entity(PassiveBluetoothCoordinatorEntity[DataCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle data update."""
+        if not self.enabled:
+            return
+
         self._async_update_attrs()
+
+        if not self.hass or self.entity_id is None:
+            return
+
+        if (current_state := self.hass.states.get(self.entity_id)) is not None:
+            new_state, new_attributes, *_ = self._Entity__async_calculate_state()
+            if (
+                new_state == current_state.state
+                and new_attributes == current_state.attributes
+            ):
+                return
+
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,114 @@
+"""Tests for the base entity helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.ld2410.number import LightSensitivityNumber
+
+
+@pytest.fixture
+def coordinator() -> SimpleNamespace:
+    """Return a minimal coordinator stub for testing."""
+
+    device = SimpleNamespace(
+        parsed_data={"light_threshold": 10},
+        is_reconnecting=False,
+        is_connected=True,
+        subscribe=MagicMock(return_value=lambda: None),
+        update=AsyncMock(),
+    )
+
+    return SimpleNamespace(
+        device=device,
+        ble_device=SimpleNamespace(address="AA:BB:CC:DD:EE:FF"),
+        base_unique_id="test-device",
+        model=SimpleNamespace(name="LD2410"),
+        device_name="Test device",
+        last_update_success=True,
+    )
+
+
+@dataclass(slots=True)
+class _DummyPlatform:
+    """Minimal platform stub for entities."""
+
+    platform_name: str = "number"
+    domain: str = "number"
+    default_language_platform_translations: dict[str, str] | None = None
+    component_translations: dict[str, str] | None = None
+    platform_translations: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.default_language_platform_translations is None:
+            self.default_language_platform_translations = {}
+        if self.component_translations is None:
+            self.component_translations = {}
+        if self.platform_translations is None:
+            self.platform_translations = {}
+
+
+@pytest.fixture
+def entity(hass: HomeAssistant, coordinator: SimpleNamespace) -> LightSensitivityNumber:
+    """Return a configured entity instance."""
+
+    entity = LightSensitivityNumber(coordinator)
+    entity.hass = hass
+    entity.entity_id = "number.test_ld2410"
+    entity.platform = _DummyPlatform()
+    entity.registry_entry = None
+    return entity
+
+
+async def test_handle_update_skips_disabled_entity(
+    hass: HomeAssistant, coordinator: SimpleNamespace
+) -> None:
+    """Disabled entities should not trigger state writes."""
+
+    test_entity = LightSensitivityNumber(coordinator)
+    test_entity.hass = hass
+    test_entity.entity_id = "number.test_disabled"
+    test_entity.platform = _DummyPlatform()
+    test_entity.registry_entry = SimpleNamespace(disabled=True, disabled_by="user")
+
+    with patch.object(test_entity, "async_write_ha_state") as mock_write:
+        test_entity._handle_coordinator_update()
+
+    mock_write.assert_not_called()
+
+
+async def test_handle_update_skips_when_state_unchanged(
+    hass: HomeAssistant, entity: LightSensitivityNumber
+) -> None:
+    """Repeated updates with the same data should be ignored."""
+
+    entity._handle_coordinator_update()
+    await hass.async_block_till_done()
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        await hass.async_block_till_done()
+
+    mock_write.assert_not_called()
+
+
+async def test_handle_update_writes_state_on_change(
+    hass: HomeAssistant, entity: LightSensitivityNumber, coordinator: SimpleNamespace
+) -> None:
+    """State changes should be forwarded to Home Assistant."""
+
+    entity._handle_coordinator_update()
+    await hass.async_block_till_done()
+
+    coordinator.device.parsed_data = {"light_threshold": 42}
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        await hass.async_block_till_done()
+
+    mock_write.assert_called_once()


### PR DESCRIPTION
## Summary
- prevent LD2410 entities from propagating coordinator updates when they are disabled or when their state has not changed
- add targeted tests that ensure coordinator updates are ignored when no state change occurs and still write when data changes

## Reasoning
- coordinator callbacks were generating unnecessary entity updates, especially for disabled entities, which led to excessive Home Assistant state writes

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`
- `pytest --cov=custom_components.ld2410 --cov-report=term`

## Coverage
- 85%


------
https://chatgpt.com/codex/tasks/task_e_68db06021f108330b6efcbdc0a8e647b