### PR TITLE
Fix #92 - Correct the photo_sensor entity units

### DIFF
--- a/custom_components/ld2410/sensor.py
+++ b/custom_components/ld2410/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    LIGHT_LUX,
     EntityCategory,
     UnitOfLength,
 )
@@ -115,6 +116,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     "photo_sensor": SensorEntityDescription(
         key="photo_sensor",
         name="Photo sensor",
+        native_unit_of_measurement=LIGHT_LUX,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ILLUMINANCE,
         entity_registry_enabled_default=False,


### PR DESCRIPTION
According to [Home Assistant Sensor Entity documentation](https://developers.home-assistant.io/docs/core/entity/sensor/) if a device class is specified, the sensor entity also needs to return the correct unit of measurement. The illuminance sensor did not have units specified.  This change adds the correct units to the 'photo_sensor' entity.
