### PR TITLE
Add LD2401 Bluetooth discovery matcher

### DIFF
--- a/custom_components/ld2410/manifest.json
+++ b/custom_components/ld2410/manifest.json
@@ -9,6 +9,9 @@
       "local_name": "HLK-LD2410_*"
     },
     {
+      "local_name": "HLK-LD2401_*"
+    },
+    {
       "manufacturer_id": 256,
       "manufacturer_data_start": [7, 1],
       "service_uuid": "0000af30-0000-1000-8000-00805f9b34fb"


### PR DESCRIPTION
## Summary

- Add the Bluetooth local-name matcher `HLK-LD2401_*` alongside the existing LD2410 matchers.
- Leave the existing service UUID, manufacturer-data matcher, integration domain/name, and all unrelated files unchanged.

## Rationale

Issue #91 reports that LD2401 works when detected through the LD2410 integration, but is not currently discovered by its advertised BLE local name. This change enables discovery only; it does not claim compatibility beyond discovery.

## Verification

- Compared the branch against the latest `main`: one commit ahead and zero commits behind.
- Confirmed the diff contains only `custom_components/ld2410/manifest.json` with three added JSON lines and no deletions.
- Parsed both manifests and confirmed removing the new matcher makes them identical.