### PR TITLE
Add root-level MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Leandro Trindade
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### Motivation
- The repository must include an explicit root-level license to satisfy HACS and general open-source requirements, so add the canonical MIT License text and copyright attribution.

### Description
- Added a single root-level file `LICENSE` containing the standard MIT License with copyright attributed to Leandro Trindade (2026), and kept the change isolated to that file on a dedicated branch.

### Testing
- Ran `ruff format .` which completed successfully and any unrelated formatting edits were reverted to keep this PR license-only.
- Ran `ruff check . --fix` which proposed unrelated fixes (31 applied then reverted) and reported 10 pre-existing lint issues; those are pre-existing and not introduced by this change. 
- Ran `pytest` which resulted in `99 passed, 1 failed` (one pre-existing diagnostics snapshot failure) under the available dependency set. 
- Measured coverage with `pytest --cov=custom_components` and obtained **85%** coverage (1532 statements, 232 missed), which meets the repository requirement (>80%).
- Verified HACS prerequisite by confirming `LICENSE` exists at the repository root and contains the canonical MIT permission and warranty clauses using `test -f LICENSE` and `rg` checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a497a994483308817af1f6e31b7aa)